### PR TITLE
Revert Codex articles to pre-image state

### DIFF
--- a/content/blog/043-codex/index.en.md
+++ b/content/blog/043-codex/index.en.md
@@ -1,0 +1,106 @@
++++
+title = 'How to Use Codex CLI'
+date = 2025-10-12T10:00:00+09:00
+draft = false
+categories = ['Engineering']
+tags = ['Codex', 'CLI', 'AI', 'Tools']
++++
+
+## Overview
+This article summarizes how to access Codex from your local environment via the command line with Codex CLI. It covers installation, sign-in methods, command execution examples, and common commands.
+
+## How to Install Codex CLI
+If you already have Node.js, you can install it via npm:
+
+```bash
+npm install -g codex-cli
+```
+
+If you use Homebrew, you can also install it as follows:
+
+```bash
+brew tap codexcli/tap
+brew install codex
+```
+
+After installation, run the following and confirm the version is displayed:
+
+```bash
+codex --version
+```
+
+## How to Sign In
+Codex CLI requires authentication on the first run. You can sign in with either an API key or your ChatGPT account, depending on your use case.
+
+### Sign in with an API key
+```bash
+codex login --token <YOUR_API_KEY>
+```
+
+You can also store it in an environment variable to avoid typing it every time:
+
+```bash
+export CODEX_API_KEY=<YOUR_API_KEY>
+```
+
+### Sign in with your ChatGPT account
+If you prefer the browser-based flow, omit the token and run `codex login`:
+
+```bash
+codex login
+```
+
+This opens a browser and shows the ChatGPT sign-in screen. Sign in with your email, Google, or Apple account, grant access, and the token will be saved when you return to the CLI.
+
+After signing in, run the following command in either case. If your account information appears, authentication succeeded.
+
+```bash
+codex whoami
+```
+
+## How to Run Codex (with examples)
+### Generate code with a one-off prompt
+
+```bash
+codex run "Write FizzBuzz in Python"
+```
+
+### Summarize while attaching a file as context
+
+```bash
+codex run "Summarize this file" --file README.md
+```
+
+### Try interactive chat mode
+
+```bash
+codex chat
+```
+
+In chat mode, you can enter prompts to receive responses in sequence. Press `Ctrl + D` to exit.
+
+#### Slash commands in chat
+In chat mode, type a `/` prefix to perform helper actions.
+
+| Command | Purpose |
+| --- | --- |
+| `/help` | Display available commands |
+| `/new` | Reset the conversation history and start a new thread |
+| `/file <path>` | Attach the specified file as context |
+| `/exit` | Exit chat |
+
+## How to Use the Commands
+Here are the main commands:
+
+| Command | Description |
+| --- | --- |
+| `codex login --token <API_KEY>` | Sign in with an API key |
+| `codex login` | Start browser authentication with your ChatGPT account |
+| `codex whoami` | Check the currently signed-in account |
+| `codex run "<prompt>"` | Send a one-off prompt and get the result |
+| `codex run "<prompt>" --file <path>` | Run with a file included as context |
+| `codex chat` | Use interactive chat mode |
+| `codex history` | Review recent execution history |
+
+## Summary
+Once installed and signed in, you can immediately start using Codex from the command line. Knowing the frequently used commands helps you quickly generate scripts or summarize files.

--- a/content/blog/043-codex/index.md
+++ b/content/blog/043-codex/index.md
@@ -1,0 +1,108 @@
++++
+title = 'Codex CLIの使い方まとめ'
+date = 2025-10-12T10:00:00+09:00
+draft = false
+categories = ['Engineering']
+tags = ['Codex', 'CLI', 'AI', 'Tools']
++++
+
+## 概要
+Codex CLIを使ってローカル環境からコマンドライン経由でCodexにアクセスする手順をまとめました。
+インストールからサインイン、代表的なコマンドの使い方まで一通り確認できます。
+
+## Codex CLIのインストール方法
+Node.jsが入っている環境ならnpm経由で簡単に導入できます。
+
+```bash
+npm install -g codex-cli
+```
+
+Homebrewを利用している場合は以下でもOKです。
+
+```bash
+brew tap codexcli/tap
+brew install codex
+```
+
+インストール後、バージョンが表示されれば準備完了です。
+
+```bash
+codex --version
+```
+
+## サインインの方法
+Codex CLIは初回実行時に認証が必要です。用途に応じてAPIキーかChatGPTアカウントでサインインできます。
+
+### APIキーでサインインする
+```bash
+codex login --token <YOUR_API_KEY>
+```
+
+環境変数に設定しておくと毎回入力する手間を省けます。
+
+```bash
+export CODEX_API_KEY=<YOUR_API_KEY>
+```
+
+### ChatGPTのアカウントでサインインする
+ブラウザでの認証フローを利用したい場合は、トークン指定を省いて `codex login` を実行します。
+
+```bash
+codex login
+```
+
+上記を実行するとブラウザが開き、ChatGPTのサインイン画面が表示されます。メールアドレスやGoogle/Appleアカウントでサインインし、許可を与えるとCLIに戻ってトークンが保存されます。
+
+サインイン後は共通で以下を実行し、アカウント情報が表示されれば認証成功です。
+
+```bash
+codex whoami
+```
+
+## Codexの実行方法とサンプル
+### 単発でコード生成を行う
+
+```bash
+codex run "PythonでFizzBuzzを書いて"
+```
+
+### ファイルをコンテキストに含めて要約する
+
+```bash
+codex run "このファイルを要約して" --file README.md
+```
+
+### 対話モードで試す
+
+```bash
+codex chat
+```
+
+チャットモードでは、プロンプトを入力すると逐次回答が返ってきます。`Ctrl + D` で終了できます。
+
+#### チャット内のスラッシュコマンド
+対話モードでは先頭に `/` を付けて補助操作を行えます。
+
+| コマンド | 役割 |
+| --- | --- |
+| `/help` | 利用可能なコマンド一覧を表示する |
+| `/new` | 会話履歴をリセットして新しいスレッドを開始する |
+| `/file <path>` | 指定したファイルをコンテキストに添付する |
+| `/exit` | チャットを終了する |
+
+## コマンドの使い方
+主なコマンドは以下の通りです。
+
+| コマンド | 説明 |
+| --- | --- |
+| `codex login --token <API_KEY>` | APIキーでサインインする |
+| `codex login` | ChatGPTのアカウントでブラウザ認証を開始する |
+| `codex whoami` | 現在サインインしているアカウントを確認する |
+| `codex run "<prompt>"` | 単発のプロンプトを投げて結果を取得する |
+| `codex run "<prompt>" --file <path>` | ファイルをコンテキストに含めて実行する |
+| `codex chat` | 対話モードで利用する |
+| `codex history` | 直近の実行履歴を確認する |
+
+## まとめ
+Codex CLIはインストール後にサインインを済ませるだけで、コマンドラインからすぐにCodexを活用できます。
+よく使うコマンドを覚えておくと、スクリプト生成やファイル要約が素早く行えるようになります。


### PR DESCRIPTION
## Summary
- remove the sign-in screenshot reference from both Japanese and English Codex CLI articles
- drop the sign-in PNG asset so the articles match their pre-image state

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f57f00a788320baa9dd0298320ef8)