### PR TITLE
Add Assistants API help bot article

### DIFF
--- a/content/blog/044-assistants-api/index.en.md
+++ b/content/blog/044-assistants-api/index.en.md
@@ -1,0 +1,130 @@
++++
+title = 'Getting Started with an Interactive Help Bot using the OpenAI Assistants API'
+date = 2025-12-21T21:39:59+09:00
+draft = false
+categories = ['Engineering']
+tags = ['OpenAI', 'Assistants API', 'Python', 'API']
++++
+
+## Overview
+This article walks through building an interactive help bot with the OpenAI Assistants API. You’ll learn how to set up the Python client, upload project files, run threads, and stream responses while the assistant uses file search.
+
+## Prerequisites
+- Python 3.9 or later
+- An OpenAI API key
+- Ability to install packages with `pip`
+
+## Setup
+Create a project directory and install the required libraries:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install openai>=1.57.0 python-dotenv
+```
+
+Keep your API key in a `.env` file:
+
+```bash
+echo "OPENAI_API_KEY=sk-xxxxx" > .env
+```
+
+## Create an Assistant
+Start by creating one assistant and enabling tools such as file search.
+
+```python
+# create_assistant.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+assistant = client.beta.assistants.create(
+    name="Docs Helper",
+    instructions="Reference the project documents and answer concisely.",
+    # Use gpt-5.1-mini for speed/cost, or gpt-5.1 when you need higher quality
+    model="gpt-5.1-mini",
+    tools=[{"type": "file_search"}],
+)
+
+print(assistant.id)
+```
+
+## Upload files
+Upload local manuals or source files so the assistant can search them.
+
+```python
+# upload_and_attach.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+file_ids = []
+for path in ["README.md", "docs/guide.pdf"]:
+    uploaded = client.files.create(file=open(path, "rb"), purpose="assistants")
+    file_ids.append(uploaded.id)
+
+assistant_id = "asst_xxx"  # Retrieved from create_assistant.py
+client.beta.assistants.update(
+    assistant_id=assistant_id,
+    tool_resources={"file_search": {"file_ids": file_ids}},
+)
+```
+
+## Create a thread and add a message
+Store user questions in a thread before executing the run.
+
+```python
+# create_thread.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+thread = client.beta.threads.create(
+    messages=[
+        {"role": "user", "content": "How do I set up this repository?"},
+    ]
+)
+
+print(thread.id)
+```
+
+## Run and stream responses
+Use `beta.threads.runs.create_and_stream` to stream the answer and observe tool calls.
+
+```python
+# run_thread_stream.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+assistant_id = "asst_xxx"
+thread_id = "thread_xxx"
+
+with client.beta.threads.runs.create_and_stream(
+    thread_id=thread_id,
+    assistant_id=assistant_id,
+    response_format={"type": "text"},
+) as stream:
+    for event in stream:
+        if event.type == "text.delta":
+            print(event.delta.value, end="", flush=True)
+```
+
+`text.delta` events contain streamed tokens, and `text.completed` signals the end. Tool invocation updates are also emitted on the same stream.
+
+## Operational tips
+- **Model choice:** Use `gpt-5.1-mini` for lower cost/latency and `gpt-5.1` when quality matters most; if a 4.x tier is sufficient, `gpt-4.1-mini`/`gpt-4.1` still works.
+- **File granularity:** Split long manuals into smaller sections before uploading to improve search accuracy.
+- **Access control:** Limit uploads that contain sensitive data and manage keys via environment variables or secret managers.
+- **Rate limits:** Queue thread creation under heavy load and add backoff retries when you hit HTTP 429 responses.
+
+## Summary
+With file search and threaded runs, the Assistants API makes it straightforward to build a “docs-savvy help bot.” Start with a small set of project files, then expand the file set and tools as your use case grows.

--- a/content/blog/044-assistants-api/index.md
+++ b/content/blog/044-assistants-api/index.md
@@ -1,0 +1,132 @@
++++
+title = 'OpenAI Assistants APIで作る対話型ヘルプボット入門'
+date = 2025-12-21T21:39:59+09:00
+draft = false
+categories = ['Engineering']
+tags = ['OpenAI', 'Assistants API', 'Python', 'API']
++++
+
+## 概要
+OpenAI Assistants APIを使い、ローカルのコードやマニュアルを参照しながら回答する対話型ヘルプボットを作る手順をまとめます。Pythonクライアントでのセットアップ、ファイルアップロード、スレッド実行、ストリーミング取得までを通して一連の流れを確認します。
+
+## 前提条件
+- Python 3.9以降がインストールされていること
+- OpenAI APIキーが取得済みであること
+- `pip`でパッケージを追加できる環境
+
+## セットアップ
+プロジェクトディレクトリを用意し、必要なライブラリをインストールします。
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install openai>=1.57.0 python-dotenv
+```
+
+`.env`にAPIキーを記載しておくと安全です。
+
+```bash
+echo "OPENAI_API_KEY=sk-xxxxx" > .env
+```
+
+## Assistantの作成
+まずはアシスタントを1つ作成します。ツールとしてコード実行やファイル検索を有効にできます。
+
+```python
+# create_assistant.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+assistant = client.beta.assistants.create(
+    name="Docs Helper",
+    instructions="プロジェクトのドキュメントを参照し、簡潔に回答してください。",
+    # 高速・軽量なら gpt-5.1-mini、精度優先なら gpt-5.1 など 5 系を選ぶ
+    model="gpt-5.1-mini",
+    tools=[{"type": "file_search"}],
+)
+
+print(assistant.id)
+```
+
+## ファイルのアップロード
+ローカルのマニュアルやサンプルコードを検索対象にするには、ファイルをアップロードしてアシスタントに紐付けます。
+
+```python
+# upload_and_attach.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+# PDFやMarkdownなど複数ファイルをアップロード
+file_ids = []
+for path in ["README.md", "docs/guide.pdf"]:
+    uploaded = client.files.create(file=open(path, "rb"), purpose="assistants")
+    file_ids.append(uploaded.id)
+
+# 既存アシスタントにファイル検索リソースを設定
+assistant_id = "asst_xxx"  # create_assistant.pyで取得したID
+client.beta.assistants.update(
+    assistant_id=assistant_id,
+    tool_resources={"file_search": {"file_ids": file_ids}},
+)
+```
+
+## スレッドを作成しメッセージを送る
+ユーザーの質問はスレッドに溜め、実行時にまとめて処理します。
+
+```python
+# create_thread.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+thread = client.beta.threads.create(
+    messages=[
+        {"role": "user", "content": "このリポジトリのセットアップ手順を教えて"},
+    ]
+)
+
+print(thread.id)
+```
+
+## 実行とストリーミング受信
+`beta.threads.runs.create_and_stream`を使うと、回答を逐次受信できます。ツール呼び出しが発生した場合のイベントも同じストリームで受け取れます。
+
+```python
+# run_thread_stream.py
+from openai import OpenAI
+from dotenv import load_dotenv
+load_dotenv()
+
+client = OpenAI()
+
+assistant_id = "asst_xxx"
+thread_id = "thread_xxx"
+
+with client.beta.threads.runs.create_and_stream(
+    thread_id=thread_id,
+    assistant_id=assistant_id,
+    response_format={"type": "text"},
+) as stream:
+    for event in stream:
+        if event.type == "text.delta":
+            print(event.delta.value, end="", flush=True)
+```
+
+`text.delta`でトークンが届き、最終的に`text.completed`で終了します。ファイル検索やツール呼び出しの進捗もイベントで確認できます。
+
+## 補足: 運用時のポイント
+- **モデル選択:** コストと速度を重視するなら`gpt-5.1-mini`、精度重視なら`gpt-5.1`を使い分けます。4系で十分な場合は`gpt-4.1-mini`/`gpt-4.1`でも動作します。
+- **ファイルの粒度:** マニュアルは章ごとに分割してアップロードすると検索精度が上がります。
+- **権限管理:** 秘匿情報を含む場合はアップロード対象を絞り、キー管理は環境変数やシークレットマネージャーで行います。
+- **レート制限:** 同時実行が多い場合はスレッド生成をキューイングし、HTTP 429が返ったらリトライバックオフを入れると安定します。
+
+## まとめ
+Assistants APIでは、ファイル検索とスレッド実行を組み合わせるだけで「社内ドキュメントに強いヘルプボット」が作れます。まずは小規模なリポジトリから試し、必要に応じてファイルやツールを拡張するとスムーズです。


### PR DESCRIPTION
## Summary
- add Japanese article covering setup and usage of the OpenAI Assistants API for a file-aware help bot, refreshed to highlight gpt-5.x model options
- add English counterpart with examples for assistant creation, file upload, thread runs, and streaming responses using gpt-5.x guidance

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e972d09c832082fe9b058ecdd40a)