### PR TITLE
Use `uv` to install OpenAI Python SDK in Response API blog posts

### DIFF
--- a/content/blog/044-openai-response-api/index.en.md
+++ b/content/blog/044-openai-response-api/index.en.md
@@ -1,0 +1,64 @@
++++
+title = 'How to Use the OpenAI Response API'
+date = 2025-02-15T10:00:00+09:00
+draft = false
+categories = ['Engineering']
+tags = ['OpenAI', 'ResponseAPI', 'Python', 'API']
++++
+
+## Overview
+This article summarizes how to use the OpenAI Response API for text generation. It covers the official documentation, how to obtain an API key, and a minimal Python example.
+
+## What is the Response API?
+The Response API is OpenAI's unified API for text generation, tool calls, and multi-turn interactions. It works for both one-off requests and conversational workflows.
+
+## Official documentation
+The most reliable source for the latest specs is the official documentation.
+
+- Response API reference: <https://platform.openai.com/docs/api-reference/responses>
+
+## How to get an API key
+You need an OpenAI API key to use the Response API. Follow these steps:
+
+1. Sign in to the OpenAI dashboard
+2. Open the API Keys page: <https://platform.openai.com/api-keys>
+3. Create a new key with “Create new secret key”
+
+Store the key in an environment variable for safety.
+
+```bash
+export OPENAI_API_KEY="<YOUR_API_KEY>"
+```
+
+## Python sample code
+Install the Python SDK with uv:
+
+```bash
+uv pip install openai
+```
+
+Below is a minimal sample that calls the Response API.
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+response = client.responses.create(
+    model="gpt-4.1-mini",
+    input="Summarize the key features of the Response API in 3 lines.",
+)
+
+print(response.output_text)
+```
+
+### Example output
+
+```text
+The Response API is a unified endpoint for one-off and conversational generation.
+It lets you retrieve model output with a simple request structure.
+Start with the docs and expand as your use case grows.
+```
+
+## Summary
+The Response API is a straightforward way to generate text with OpenAI. Check the docs, prepare an API key, and try the Python SDK for a smooth start.

--- a/content/blog/044-openai-response-api/index.md
+++ b/content/blog/044-openai-response-api/index.md
@@ -1,0 +1,68 @@
++++
+title = 'OpenAI Response APIの使い方まとめ'
+date = 2025-02-15T10:00:00+09:00
+draft = false
+categories = ['Engineering']
+tags = ['OpenAI', 'ResponseAPI', 'Python', 'API']
++++
+
+## 概要
+OpenAIのResponse APIを使ってテキスト生成を行う手順をまとめました。
+公式ドキュメントの場所、APIキーの取得方法、Pythonからの最小サンプルまでを確認できます。
+
+## Response APIとは
+Response APIは、テキスト生成やツール呼び出しなどを統一的に扱えるOpenAIのAPIです。
+単発の問い合わせから、会話形式のやり取りまで幅広く利用できます。
+
+## 公式ドキュメント
+最新の仕様は公式ドキュメントを参照するのが確実です。
+
+- Response API リファレンス: <https://platform.openai.com/docs/api-reference/responses>
+
+## APIキーの取得方法
+Response APIを利用するにはOpenAIのAPIキーが必要です。
+以下の手順で取得できます。
+
+1. OpenAIのダッシュボードにサインインする
+2. API Keysページ（<https://platform.openai.com/api-keys>）を開く
+3. 「Create new secret key」から新しいキーを発行する
+
+取得したキーは環境変数に設定しておくと安全です。
+
+```bash
+export OPENAI_API_KEY="<YOUR_API_KEY>"
+```
+
+## Pythonのサンプルコード
+Python SDKを使う場合は、まずuvでパッケージをインストールします。
+
+```bash
+uv pip install openai
+```
+
+以下はResponse APIでテキストを生成する最小サンプルです。
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+response = client.responses.create(
+    model="gpt-4.1-mini",
+    input="Response APIの特徴を3行で教えてください。",
+)
+
+print(response.output_text)
+```
+
+### 実行イメージ
+
+```text
+Response APIは単発の生成にも対話にも使える統一APIです。
+シンプルなリクエストでモデル出力を取得できます。
+公式ドキュメントを確認しながら用途に合わせて拡張できます。
+```
+
+## まとめ
+Response APIはシンプルな入力でテキスト生成を行えるOpenAIのAPIです。
+公式ドキュメントを確認し、APIキーを準備してからPythonで試すとスムーズに導入できます。


### PR DESCRIPTION
### Motivation
- Align the Python SDK installation instructions with the repository's preferred `uv` workflow used elsewhere.
- Keep Japanese and English versions of the Response API article consistent.
- Provide readers a reproducible install command using `uv` for creating virtual environments and installing packages.
- Update documentation files to reflect the chosen package manager for clarity during setup.

### Description
- Replaced `pip install openai` with `uv pip install openai` in `content/blog/044-openai-response-api/index.md` and `content/blog/044-openai-response-api/index.en.md`.
- Ensured the sample code and `export OPENAI_API_KEY` guidance remain unchanged while installation instructions were updated.
- Kept article frontmatter and example `OpenAI` usage intact to avoid behavioral changes.
- Synchronized Japanese and English articles so both show the same `uv`-based setup steps.

### Testing
- No automated tests were run because this is a content-only change.
- Content was committed after edits and aligned across both language files.
- CI (if configured) will validate site build on merge; no local automated test run was performed.
- Manual verification limited to ensuring the install command was updated in both files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd81f8754832098d765def205e4ba)