### PR TITLE
fix: 404ページへのリダイレクト設定と非公開記事の再公開

### DIFF
--- a/content/blog/001-hugo-netlify-build/index.en.md
+++ b/content/blog/001-hugo-netlify-build/index.en.md
@@ -5,6 +5,7 @@ draft = false
 toc = true
 categories = ['Engineering']
 tags = ['Hugo', 'Netlify', 'Github', 'Favicon']
+aliases = ['/en/blog/010-favicon/']
 +++
 ## Overview
 This document describes the steps to create a site with Hugo, manage it with Github, and build it with Netlify from scratch.

--- a/content/blog/001-hugo-netlify-build/index.md
+++ b/content/blog/001-hugo-netlify-build/index.md
@@ -5,6 +5,7 @@ date = 2023-12-02T00:59:37+09:00
 draft = false
 categories = ['Engineering']
 tags = ['Hugo', 'Netlify', 'Github', 'Favicon']
+aliases = ['/blog/010-favicon/']
 +++
 ## 概要
 Hugoで作ったサイトをGithubで管理、Netlifyでビルドした手順を0から作れるよう記載します。

--- a/content/blog/004-python-setup/index.en.md
+++ b/content/blog/004-python-setup/index.en.md
@@ -4,6 +4,7 @@ date = 2023-12-10T23:19:33+09:00
 draft = false
 categories = ['Engineering']
 tags = ['python', 'mac']
+aliases = ['/en/blog/004-paython-setup/']
 +++
 
 ## Overview

--- a/content/blog/004-python-setup/index.md
+++ b/content/blog/004-python-setup/index.md
@@ -5,6 +5,7 @@ date = 2023-12-10T23:19:33+09:00
 draft = false
 categories = ['Engineering']
 tags = ['python', 'mac']
+aliases = ['/blog/004-paython-setup/']
 +++
 
 ## 概要

--- a/content/blog/017-vscode-copilot/index.en.md
+++ b/content/blog/017-vscode-copilot/index.en.md
@@ -4,6 +4,7 @@ date = 2024-02-04T22:34:51+09:00
 draft = false
 categories = ['Engineering']
 tags = ['VSCode', 'Copilot', 'GitHub Copilot', 'Chat tool']
+aliases = ['/en/blog/035-github-copilot-markdown/', '/en/blog/042-github-copilot/']
 +++
 
 ## Overview

--- a/content/blog/017-vscode-copilot/index.md
+++ b/content/blog/017-vscode-copilot/index.md
@@ -5,6 +5,7 @@ date = 2024-02-04T22:34:51+09:00
 draft = false
 categories = ['Engineering']
 tags = ['VSCode', 'Copilot', 'GitHub Copilot', 'Chat tool']
+aliases = ['/blog/035-github-copilot-markdown/', '/blog/042-github-copilot/']
 +++
 
 ## 概要

--- a/content/blog/034-jetbrains-update/index.en.md
+++ b/content/blog/034-jetbrains-update/index.en.md
@@ -1,7 +1,7 @@
 +++
 title = 'How to Upgrade JetBrains Products to a Major Version'
 date = 2025-06-12T20:46:53+09:00
-draft = true
+draft = false
 +++
 
 ## Overview

--- a/content/blog/034-jetbrains-update/index.md
+++ b/content/blog/034-jetbrains-update/index.md
@@ -2,7 +2,7 @@
 title = 'JetBrains製品のメジャーバージョンを上げる方法'
 description = 'IntelliJやPyCharmなどJetBrains製品のメジャーバージョンアップ方法を解説。JetBrains Toolbox Appを使って設定を引き継ぎながら簡単にアップデートする手順を紹介します。'
 date = 2025-06-12T20:46:53+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['jetBrains', 'Intellij']
 +++

--- a/content/blog/038-update-vscode/index.en.md
+++ b/content/blog/038-update-vscode/index.en.md
@@ -1,7 +1,7 @@
 +++
 title = 'How to Update Visual Studio Code'
 date = 2025-07-27T18:12:16+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['vscode', 'update']
 +++

--- a/content/blog/038-update-vscode/index.md
+++ b/content/blog/038-update-vscode/index.md
@@ -2,7 +2,7 @@
 title = 'Visual Studio Codeのアップデート方法'
 description = 'MacでVisual Studio Codeをアップデートする手順を解説。更新の確認から再起動、バージョン確認まで画像付きでわかりやすく紹介します。'
 date = 2025-07-27T18:12:16+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['vscode', 'update']
 +++

--- a/content/page/search/_index.en.md
+++ b/content/page/search/_index.en.md
@@ -2,12 +2,14 @@
 title: "Search"
 slug: "search"
 layout: "search"
+aliases:
+    - /en/blog/search/
 outputs:
     - html
     - json
 menu:
     main:
         weight: 4
-        params: 
+        params:
             icon: search
 ---

--- a/content/page/search/_index.md
+++ b/content/page/search/_index.md
@@ -2,6 +2,8 @@
 title: "Search"
 slug: "search"
 layout: "search"
+aliases:
+    - /blog/search/
 outputs:
     - html
     - json


### PR DESCRIPTION
## Summary
- 統合された記事の旧URLにHugoの`aliases`でリダイレクトを設定し、404エラーを解消
- 非公開だった2記事（034, 038）を再公開
- 空の英語ファイル（030-covariance）を削除

## 変更内容

### リダイレクト設定（日英両対応）
| 旧URL | リダイレクト先 | 理由 |
|---|---|---|
| `/blog/004-paython-setup/` | `/blog/004-python-setup/` | タイポ修正によるリネーム |
| `/blog/search/` | `/page/search/` | 検索ページの移動 |
| `/blog/010-favicon/` | `/blog/001-hugo-netlify-build/` | 記事統合 |
| `/blog/035-github-copilot-markdown/` | `/blog/017-vscode-copilot/` | 記事統合 |
| `/blog/042-github-copilot/` | `/blog/017-vscode-copilot/` | 記事統合 |

### 記事の再公開
- `034-jetbrains-update`（JP/EN）
- `038-update-vscode`（JP/EN）

### 削除
- `030-covariance/index.en.md`（空ファイル）

## Test plan
- [ ] `hugo --minify` でビルドが成功すること
- [ ] リダイレクト元URLにアクセスしてリダイレクト先に遷移すること
- [ ] 034, 038の記事が日英ともに表示されること