### PR TITLE
feat: VSCodeアップデート記事の品質改善

### DIFF
--- a/content/blog/038-update-vscode/index.en.md
+++ b/content/blog/038-update-vscode/index.en.md
@@ -1,33 +1,125 @@
 +++
 title = 'How to Update Visual Studio Code'
+description = 'A complete guide to updating Visual Studio Code on Mac. Covers GUI updates, Homebrew command-line updates, auto-update settings, and troubleshooting tips.'
 date = 2025-07-27T18:12:16+09:00
 draft = true
 categories = ['Engineering']
-tags = ['vscode', 'update']
+tags = ['VSCode', 'update']
 +++
 
 ## Overview
-This article explains how to update Visual Studio Code (VSCode) on Mac.
 
-## How to Update VSCode
+This article explains how to update Visual Studio Code (VSCode) on Mac.
+In addition to manual GUI updates, it also covers command-line updates and auto-update settings.
+
+## Updating via GUI
 
 1. Launch VSCode.
-2. Go to Code → "Check for Updates".  
-   If your interface is in English, select "Update Visual Studio Code".
+2. Go to Code → "Check for Updates".
 
 ![Check for Updates](image.png)
 
 When the update starts, you will see a screen like this:
 
-![alt text](image-1.png)
+![Downloading update](image-1.png)
 
 Once the download is complete, "Restart to Update" will be displayed.
 
 After restarting, click "About Visual Studio Code" to confirm that the version has been updated.
 
-![Version](image-3.png)
+![Version confirmation screen](image-3.png)
+
+## Updating via Command Line
+
+If you installed VSCode via Homebrew, you can update it from the terminal.
+
+### Check the current version
+
+```bash
+code --version
+```
+
+### Update with Homebrew
+
+```bash
+brew upgrade --cask visual-studio-code
+```
+
+If VSCode was not installed via Homebrew, first remove the existing VSCode from your Applications folder, then install it via Homebrew.
+Your settings and extensions can be restored via account sync, so removing it is safe.
+
+```bash
+brew install --cask visual-studio-code
+```
+
+After this, you can use `brew upgrade --cask visual-studio-code` for future updates.
+
+## Auto-Update Settings
+
+VSCode has an `update.mode` setting that controls update behavior.
+Open Settings (`Cmd + ,`) and search for `update mode` to change it.
+
+| Value | Behavior |
+|-------|----------|
+| `default` | Automatically downloads and installs updates in the background |
+| `manual` | Checks for updates but requires manual installation |
+| `start` | Only checks for updates when VSCode starts |
+| `none` | Completely disables automatic updates |
+
+To configure directly in settings.json:
+
+```json
+{
+    "update.mode": "default"
+}
+```
+
+Unless you have a specific reason, `default` is the recommended setting.
+
+## Troubleshooting
+
+### "Check for Updates" shows no updates available
+
+Auto-update may be disabled. Check that `update.mode` is not set to `none` in your settings.
+
+### Update download fails
+
+This may be caused by proxy or firewall settings. Check the following configuration:
+
+```json
+{
+    "http.proxy": "http://proxy.example.com:8080",
+    "http.proxyStrictSSL": false
+}
+```
+
+### Extensions stop working after update
+
+This may be due to extension compatibility issues. Try the following steps:
+
+1. Open the Command Palette (`Cmd + Shift + P`)
+2. Run "Extensions: Disable All Installed Extensions"
+3. Restart VSCode
+4. Re-enable extensions one by one to identify the problematic one
+
+### If the issue persists
+
+Reinstalling VSCode may resolve the problem.
+
+```bash
+# If installed via Homebrew
+brew reinstall --cask visual-studio-code
+```
+
+If you sync your settings via a GitHub or Microsoft account, your configuration and installed extensions will be automatically restored after reinstallation.
 
 ## Summary
 
-Updating VSCode is very simple and can be done in just a few clicks. By updating regularly, you can take advantage of new features and security patches, so it is important to always keep your environment up to date.  
-After updating, be sure to check the version information to confirm that the update was successful.
+This article covered how to update VSCode.
+
+- **GUI**: Code → "Check for Updates" — a few clicks to complete
+- **Command line**: `brew upgrade --cask visual-studio-code` for quick updates
+- **Auto-update**: Control behavior with the `update.mode` setting
+
+By updating regularly, you can take advantage of new features and security patches.
+After updating, always check the version information to confirm the update was successful.

--- a/content/blog/038-update-vscode/index.md
+++ b/content/blog/038-update-vscode/index.md
@@ -1,35 +1,128 @@
 +++
 title = 'Visual Studio Codeのアップデート方法'
-description = 'MacでVisual Studio Codeをアップデートする手順を解説。更新の確認から再起動、バージョン確認まで画像付きでわかりやすく紹介します。'
+description = 'MacでVisual Studio Codeをアップデートする手順を解説。GUIでの更新、Homebrewを使ったコマンドラインでの更新、自動アップデート設定、トラブルシューティングまで網羅的に紹介します。'
 date = 2025-07-27T18:12:16+09:00
 draft = true
 categories = ['Engineering']
-tags = ['vscode', 'update']
+tags = ['VSCode', 'update']
 +++
 
 ## 概要
-MacでVisual Studio Code (VSCode) のアップデート方法を説明します。
 
-## VSCodeのアップデート方法
+MacでVisual Studio Code（VSCode）のアップデート方法を説明します。
+GUIからの手動アップデートに加え、コマンドラインでの更新方法や自動アップデートの設定についても解説します。
 
-1. VScodeを起動します。
-2. Code → 「更新の確認」<br>
-   英語の場合は Update Visual Studio Code を選択します。
+## GUIからアップデートする方法
+
+1. VSCodeを起動します。
+2. Code → 「更新の確認」を選択します。
+   英語の場合は Code → "Check for Updates" を選択します。
 
 ![更新の確認](image.png)
 
+更新が始まると以下のような画面になります。
 
-更新が始まると以下のような画面になります
-
-![alt text](image-1.png)
+![アップデートのダウンロード中](image-1.png)
 
 ダウンロードが完了すると「再起動して更新」が表示されます。
 
 再起動後「Visual Studio Codeのバージョン情報」をクリックして、バージョンが上がっていることを確認します。
 
-![バージョン](image-3.png)
+![バージョン確認画面](image-3.png)
+
+## コマンドラインからアップデートする方法
+
+Homebrewを使ってVSCodeをインストールしている場合は、ターミナルからアップデートできます。
+
+### 現在のバージョンを確認
+
+```bash
+code --version
+```
+
+### Homebrewでアップデート
+
+```bash
+brew upgrade --cask visual-studio-code
+```
+
+Homebrewでインストールしていない場合は、既存のVSCodeをアプリケーションフォルダから削除した上で、以下のコマンドでHomebrewによる管理に切り替えられます。
+設定やインストール済みの拡張機能はアカウント同期で復元できるため、削除しても問題ありません。
+
+```bash
+brew install --cask visual-studio-code
+```
+
+以降は `brew upgrade --cask visual-studio-code` でアップデートが可能になります。
+
+## 自動アップデートの設定
+
+VSCodeにはアップデートの挙動を制御する `update.mode` 設定があります。
+設定画面を開き（`Cmd + ,`）、`update mode` で検索すると変更できます。
+
+| 設定値 | 挙動 |
+|--------|------|
+| `default` | バックグラウンドで自動的にアップデートをダウンロード・インストールします |
+| `manual` | アップデートの確認は行いますが、インストールは手動で行います |
+| `start` | VSCodeの起動時のみアップデートを確認します |
+| `none` | 自動アップデートを完全に無効化します |
+
+settings.jsonで直接設定する場合は以下のように記述します。
+
+```json
+{
+    "update.mode": "default"
+}
+```
+
+特別な理由がない限り `default` のままで問題ありません。
+
+## トラブルシューティング
+
+### アップデートが「更新の確認」に表示されない
+
+自動アップデートが無効になっている可能性があります。
+設定の `update.mode` が `none` になっていないか確認してください。
+
+### アップデートのダウンロードが失敗する
+
+プロキシやファイアウォールの設定が原因の場合があります。
+以下の設定を確認してください。
+
+```json
+{
+    "http.proxy": "http://proxy.example.com:8080",
+    "http.proxyStrictSSL": false
+}
+```
+
+### アップデート後に拡張機能が動作しなくなった
+
+拡張機能の互換性の問題が考えられます。以下の手順を試してください。
+
+1. コマンドパレット（`Cmd + Shift + P`）を開く
+2. 「Extensions: Disable All Installed Extensions」を実行
+3. VSCodeを再起動
+4. 拡張機能を1つずつ有効化して問題のある拡張機能を特定する
+
+### それでも解決しない場合
+
+VSCodeを再インストールすることで解決する場合があります。
+
+```bash
+# Homebrewの場合
+brew reinstall --cask visual-studio-code
+```
+
+設定やインストール済みの拡張機能はGitHubアカウントやMicrosoftアカウントで同期しておくと、再インストール後に自動で復元されます。
 
 ## まとめ
 
-VSCodeのアップデートは非常に簡単で、数クリックで完了します。定期的にアップデートを行うことで、新機能やセキュリティパッチを利用できるため、常に最新の状態を保つことが重要です。
+VSCodeのアップデート方法について解説しました。
+
+- **GUI**: Code → 「更新の確認」から数クリックで完了
+- **コマンドライン**: `brew upgrade --cask visual-studio-code` で一括更新
+- **自動アップデート**: `update.mode` 設定で挙動を制御可能
+
+定期的にアップデートを行うことで、新機能やセキュリティパッチを利用できます。
 アップデート後は、必ずバージョン情報を確認して、正しくアップデートが行われたかをチェックしましょう。


### PR DESCRIPTION
## Summary
- 038-update-vscode記事にコマンドライン更新方法、自動アップデート設定、トラブルシューティングを追加
- 英語版にdescriptionを追加し、表記の統一・alt text修正を実施
- 日英両方を同等の内容に更新

## 追加セクション
- **コマンドラインからアップデートする方法**: `brew upgrade --cask visual-studio-code` の手順
- **自動アップデートの設定**: `update.mode` の4つの設定値（`default`/`manual`/`start`/`none`）の解説
- **トラブルシューティング**: 更新が表示されない、ダウンロード失敗、拡張機能の問題、再インストール

## 修正
- `VScodeS` → `VSCode` に表記統一
- `alt text` → 適切な画像説明に修正
- 英語版に `description` を追加
- `description` を新しい記事内容に合わせて更新

## Test plan
- [ ] `hugo --minify` でビルドが成功すること
- [ ] 日本語版・英語版の記事が正しく表示されること
- [ ] コードブロック内のコマンドが正しいこと（`brew upgrade --cask visual-studio-code` 等）