### PR TITLE
chore: CLAUDE.mdの改善とタグ表記の統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,14 @@ Hugo設定は `config/_default/` に分割:
 
 ## Gitワークフロー
 
-- `main`に直接コミットしない — 必ずフィーチャーブランチを作成する
-- 変更後、コミットしてPRを作成する
+作業は以下の手順で行うこと:
+
+1. **作業開始前に `main` を最新化する**: `git checkout main && git pull`
+2. **フィーチャーブランチを作成する**: `git checkout -b <type>/<description>`
+   - ブランチ名の例: `feat/add-new-article`, `fix/redirect-404`, `chore/fix-tags`
+3. **変更をコミットする**: コミットメッセージは `<type>: <description>` 形式（例: `feat: 新しい記事を追加`）
+4. **リモートにプッシュしてPRを作成する**: `git push -u origin <branch-name>` → `gh pr create`
+
+**注意:**
+- `main`に直接コミットしない
 - テーマはgit submodule — `git clone --recurse-submodules`または`git submodule update --init`を使用

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm/yarn/package.jsonはなし — 純粋なHugoプロジェクトです。
 
 ## コンテンツ構造
 
-記事は `content/blog/NNN-topic-name/` に連番（001〜046+）で配置されます。各ディレクトリには以下を含みます:
+記事は `content/blog/NNN-topic-name/` に連番（001〜047+）で配置されます。各ディレクトリには以下を含みます:
 - `index.md` — 日本語記事（メイン）
 - `index.en.md` — 英語翻訳（すべての記事に必須）
 
@@ -41,13 +41,13 @@ description = "SEO用の説明文（120-160文字）"
 date = 2026-02-07T00:00:00+09:00
 draft = false
 categories = ["Engineering"]  # Engineering | Management | Product | Blog
-tags = ["tool-name", "topic"]  # 英語で記載、既存のタグを参照
+tags = ["tool-name", "topic"]  # 英語で記載、既存のタグと表記を合わせる（下記タグ一覧参照）
 +++
 ```
 
 ## SEO description のルール
 
-すべての記事に `description` フィールドを設定すること。これはGoogle検索結果に表示される説明文として使用される。
+日本語・英語の両方の記事に `description` フィールドを設定すること。これはGoogle検索結果に表示される説明文として使用される。
 
 **description の書き方:**
 - **文字数**: 120〜160文字（日本語）
@@ -74,6 +74,40 @@ description = 'AWS Lambda、API Gateway、S3を使ったLINE Botの実装解説�
 - コードブロックには言語指定子を付ける
 - 日本語記事と対応する英語記事（`index.en.md`）を必ず作成する
 - コンテンツの焦点: 実践的なエンジニアリングチュートリアル、ツールセットアップガイド、マネジメント/スクラム関連トピック
+
+## タグの命名ルール
+
+タグを追加する際は、既存の記事のタグと表記を統一すること。新しいタグを追加する前に `grep -h "^tags" content/blog/*/index.md | sort -u` で既存タグを確認する。
+
+**命名規則:**
+- 公式ブランド名に従う（例: `VSCode`, `GitHub`, `ChatGPT`, `IntelliJ`）
+- プログラミング言語は先頭大文字（例: `Python`, `Go`, `TypeScript`）
+- 略語・頭字語は大文字（例: `AWS`, `SEO`, `API`, `S3`）
+
+**主要タグ一覧（正式表記）:**
+`AWS`, `Lambda`, `S3`, `API Gateway`, `ChatGPT`, `Codex`, `GitHub Copilot`, `Copilot`, `Git`, `Go`, `gRPC`, `Hugo`, `IntelliJ`, `ITIL`, `LINE BOT`, `Node.js`, `OpenAI`, `Python`, `Redis`, `Scrum`, `SEO`, `TypeScript`, `VSCode`
+
+## 記事の統合・削除時のルール
+
+公開済みの記事を統合（マージ）または削除する場合、旧URLへのアクセスが404にならないよう、統合先の記事のフロントマターに `aliases` を設定すること。
+
+```toml
+# 例: 010-favicon を 001-hugo-netlify-build に統合した場合
+aliases = ['/blog/010-favicon/']
+```
+
+英語版にも対応する `aliases` を設定する:
+```toml
+aliases = ['/en/blog/010-favicon/']
+```
+
+## 技術記事の検証フロー
+
+技術的な記事（ツールのセットアップ手順、コマンドの使い方など）を作成・更新した場合、公開前に以下を確認する:
+
+1. **コマンドの正確性**: 記載したコマンドが実際に動作するか、ターミナルで確認する
+2. **公式ドキュメントとの整合性**: 設定値やオプションが公式ドキュメントと一致しているか確認する
+3. **バージョン依存性**: 特定バージョンに依存する手順がある場合、対象バージョンを明記する
 
 ## 設定
 

--- a/content/blog/004-python-setup/index.en.md
+++ b/content/blog/004-python-setup/index.en.md
@@ -3,7 +3,7 @@ title = 'Setting Up a Local Environment Using Pyenv and venv'
 date = 2023-12-10T23:19:33+09:00
 draft = false
 categories = ['Engineering']
-tags = ['python', 'mac']
+tags = ['Python', 'mac']
 aliases = ['/en/blog/004-paython-setup/']
 +++
 

--- a/content/blog/004-python-setup/index.md
+++ b/content/blog/004-python-setup/index.md
@@ -4,7 +4,7 @@ description = 'MacでPyenvとvenvを使ったPython環境構築方法を解説�
 date = 2023-12-10T23:19:33+09:00
 draft = false
 categories = ['Engineering']
-tags = ['python', 'mac']
+tags = ['Python', 'mac']
 aliases = ['/blog/004-paython-setup/']
 +++
 

--- a/content/blog/005-github-copilot/index.en.md
+++ b/content/blog/005-github-copilot/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Use GitHub Copilot in IntelliJ'
 date = 2023-12-11T22:45:40+09:00
 draft = false
 categories = ['Engineering']
-tags = ['copilot', 'intellij']
+tags = ['Copilot', 'IntelliJ']
 +++
 
 ## Overview

--- a/content/blog/005-github-copilot/index.md
+++ b/content/blog/005-github-copilot/index.md
@@ -4,7 +4,7 @@ description = 'IntelliJでGitHub Copilotを使う方法を解説。プラグイ�
 date = 2023-12-11T22:45:40+09:00
 draft = false
 categories = ['Engineering']
-tags = ['copilot', 'intellij']
+tags = ['Copilot', 'IntelliJ']
 +++
 
 ## 概要

--- a/content/blog/006-intellij-lamda-setup/index.en.md
+++ b/content/blog/006-intellij-lamda-setup/index.en.md
@@ -3,7 +3,7 @@ title = 'Efficient Lambda Development with AWS Toolkit in IntelliJ'
 date = 2023-12-12T22:40:05+09:00
 draft = false
 categories = ['Engineering']
-tags = ['Intellij', 'AWS', 'Lambda']
+tags = ['IntelliJ', 'AWS', 'Lambda']
 +++
 ## Overview
 This article explains how to efficiently develop Lambda functions using the AWS Toolkit in IntelliJ.

--- a/content/blog/006-intellij-lamda-setup/index.md
+++ b/content/blog/006-intellij-lamda-setup/index.md
@@ -4,7 +4,7 @@ description = 'IntelliJでAWS Toolkitを使ってLambda関数を開発する方�
 date = 2023-12-12T22:40:05+09:00
 draft = false
 categories = ['Engineering']
-tags = ['Intellij', 'AWS', 'Lambda']
+tags = ['IntelliJ', 'AWS', 'Lambda']
 +++
 ## 概要
 IntellijでAWS Toolkitを使ってLambdaを効率よく開発する方法を解説します。

--- a/content/blog/007-google-search-console/index.en.md
+++ b/content/blog/007-google-search-console/index.en.md
@@ -3,7 +3,7 @@ title = 'Using Google Search Console to Make Your Blog Searchable on Google'
 date = 2023-12-18T19:10:04+09:00
 draft = false
 categories = ['Engineering']
-tags = ['google search console', 'seo', 'blog']
+tags = ['google search console', 'SEO', 'blog']
 +++
 
 ## Overview

--- a/content/blog/007-google-search-console/index.md
+++ b/content/blog/007-google-search-console/index.md
@@ -4,7 +4,7 @@ description = 'Google Search Consoleでブログを検索対象にする方法�
 date = 2023-12-18T19:10:04+09:00
 draft = false
 categories = ['Engineering']
-tags = ['google search console', 'seo', 'blog']
+tags = ['google search console', 'SEO', 'blog']
 +++
 
 ## 概要

--- a/content/blog/008-aws-eventbrdge/index.en.md
+++ b/content/blog/008-aws-eventbrdge/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Schedule Lambda Functions with AWS EventBridge'
 date = 2023-12-21T23:03:13+09:00
 draft = false
 categories = ['Engineering']
-tags = ['aws', 'lambda', 'eventbridge', 'serverless']
+tags = ['AWS', 'Lambda', 'eventbridge', 'serverless']
 +++
 
 ## Overview

--- a/content/blog/008-aws-eventbrdge/index.md
+++ b/content/blog/008-aws-eventbrdge/index.md
@@ -4,7 +4,7 @@ description = 'AWS EventBridgeでLambdaを定期実行する方法を解説。cr
 date = 2023-12-21T23:03:13+09:00
 draft = false
 categories = ['Engineering']
-tags = ['aws', 'lambda', 'eventbridge', 'serverless']
+tags = ['AWS', 'Lambda', 'eventbridge', 'serverless']
 +++
 
 ## 概要

--- a/content/blog/009-light-house/index.en.md
+++ b/content/blog/009-light-house/index.en.md
@@ -3,7 +3,7 @@ title = 'Introduction to Using Lighthouse'
 date = 2023-12-22T23:08:00+09:00
 draft = false
 categories = ['Engineering']
-tags = ['lighthouse', 'seo', 'performance']
+tags = ['lighthouse', 'SEO', 'performance']
 +++
 
 ## Overview

--- a/content/blog/015-s3-object-check/index.en.md
+++ b/content/blog/015-s3-object-check/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Check if an S3 Object Exists in Python boto3'
 date = 2024-01-27T21:41:37+09:00
 draft = false
 categories = ['Engineering']
-tags = ['aws', 's3', 'Python', 'boto3']
+tags = ['AWS', 'S3', 'Python', 'boto3']
 +++
 
 ## Overview

--- a/content/blog/015-s3-object-check/index.md
+++ b/content/blog/015-s3-object-check/index.md
@@ -4,7 +4,7 @@ description = 'Python boto3でS3オブジェクトの存在確認をする方法
 date = 2024-01-27T21:41:37+09:00
 draft = false
 categories = ['Engineering']
-tags = ['aws', 's3', 'Python', 'boto3']
+tags = ['AWS', 'S3', 'Python', 'boto3']
 +++
 
 ## 概要

--- a/content/blog/023-chatgpt-create-image/index.en.md
+++ b/content/blog/023-chatgpt-create-image/index.en.md
@@ -3,7 +3,7 @@ title = 'Generating Images with ChatGPT'
 date = 2024-03-31T17:35:07+09:00
 draft = false
 categories = ['Engineering']
-tags = ['chatGPT', 'Image Generation']
+tags = ['ChatGPT', 'Image Generation']
 +++
 
 ## Overview

--- a/content/blog/023-chatgpt-create-image/index.md
+++ b/content/blog/023-chatgpt-create-image/index.md
@@ -4,7 +4,7 @@ description = 'ChatGPT PlusのDALL-E機能を使って画像を生成する方�
 date = 2024-03-31T17:35:07+09:00
 draft = false
 categories = ['Engineering']
-tags = ['chatGPT', '画像生成']
+tags = ['ChatGPT', '画像生成']
 +++
 
 ## 概要

--- a/content/blog/030-go-environment-construction/index.md
+++ b/content/blog/030-go-environment-construction/index.md
@@ -4,7 +4,7 @@ description = 'MacでGo言語の開発環境を最速で構築する方法を解
 date = 2024-09-15T16:52:04+09:00
 draft = false
 categories = ['Engineering']
-tags = ['go']
+tags = ['Go']
 +++
 
 ## 概要

--- a/content/blog/034-jetbrains-update/index.md
+++ b/content/blog/034-jetbrains-update/index.md
@@ -4,7 +4,7 @@ description = 'IntelliJやPyCharmなどJetBrains製品のメジャーバージ�
 date = 2025-06-12T20:46:53+09:00
 draft = false
 categories = ['Engineering']
-tags = ['jetBrains', 'Intellij']
+tags = ['JetBrains', 'IntelliJ']
 +++
 
 ## 概要

--- a/content/blog/035-github-copilot-markdown/index.en.md
+++ b/content/blog/035-github-copilot-markdown/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Enable GitHub Copilot for Markdown'
 date = 2025-07-21T10:00:00+09:00
 draft = true
 categories = ['Engineering']
-tags = ['GitHub Copilot', 'Markdown', 'vscode']
+tags = ['GitHub Copilot', 'Markdown', 'VSCode']
 +++
 
 ## Overview

--- a/content/blog/035-github-copilot-markdown/index.md
+++ b/content/blog/035-github-copilot-markdown/index.md
@@ -4,7 +4,7 @@ description = 'VSCodeでGitHub CopilotのMarkdown補完を有効にする設定�
 date = 2025-07-21T10:00:00+09:00
 draft = true
 categories = ['Engineering']
-tags = ['GitHub Copilot', 'Markdown', 'vscode']
+tags = ['GitHub Copilot', 'Markdown', 'VSCode']
 +++
 
 ## 概要

--- a/content/blog/036-vscode-indent/index.en.md
+++ b/content/blog/036-vscode-indent/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Customize Indent Guides in VSCode'
 date = 2025-07-22T21:01:13+09:00
 draft = false
 categories = ['Engineering']
-tags = ['vscode']
+tags = ['VSCode']
 +++
 
 ## Overview

--- a/content/blog/036-vscode-indent/index.md
+++ b/content/blog/036-vscode-indent/index.md
@@ -4,7 +4,7 @@ description = 'VSCodeのインデントガイドの色を設定ファイルで�
 date = 2025-07-22T21:01:13+09:00
 draft = false
 categories = ['Engineering']
-tags = ['vscode']
+tags = ['VSCode']
 +++
 
 ## 概要

--- a/content/blog/039-aws-toolkit-vscode/index.en.md
+++ b/content/blog/039-aws-toolkit-vscode/index.en.md
@@ -3,7 +3,7 @@ title = 'How to Use AWS Toolkit in Visual Studio Code'
 date = 2025-08-11T20:33:30+09:00
 draft = false
 categories = ['Engineering']
-tags = ['vscode', 'aws', 'toolkit']
+tags = ['VSCode', 'AWS', 'toolkit']
 +++
 
 ## Overview

--- a/content/blog/039-aws-toolkit-vscode/index.md
+++ b/content/blog/039-aws-toolkit-vscode/index.md
@@ -4,7 +4,7 @@ description = 'VSCodeにAWS Toolkitをインストールし、東京リージョ
 date = 2025-08-11T20:33:30+09:00
 draft = false
 categories = ['Engineering']
-tags = ['vscode', 'aws', 'toolkit']
+tags = ['VSCode', 'AWS', 'toolkit']
 +++
 
 ## 概要

--- a/content/blog/042-github-copilot/index.md
+++ b/content/blog/042-github-copilot/index.md
@@ -4,7 +4,7 @@ description = 'GitHub Copilot ChatのChat tool機能を使う方法を解説。c
 date = 2025-10-07T08:39:41+09:00
 draft = true
 categories = ['Engineering']
-tags = ['Github Copilot', 'VScode', 'Chat tool']
+tags = ['GitHub Copilot', 'VSCode', 'Chat tool']
 +++
 
 ## 概要


### PR DESCRIPTION
## Summary
- CLAUDE.mdに記事管理・品質向上のためのルールを追加
- 全記事のタグ表記を公式ブランド名に統一（24ファイル、11種類の不整合を修正）

## CLAUDE.mdへの追加ルール

### 1. 記事統合・削除時のリダイレクトルール
公開済み記事を統合・削除する際、統合先の記事に `aliases` を設定して旧URLからのリダイレクトを確保する

### 2. タグの命名ルール
- 既存タグの表記を確認してから追加する
- 公式ブランド名に従う（VSCode, GitHub, ChatGPT, IntelliJ等）
- 主要タグ一覧を追記

### 3. 英語版descriptionの明記
日本語・英語の両方に `description` を設定することを明記

### 4. 技術記事の検証フロー
コマンドの動作確認、公式ドキュメントとの整合性確認を公開前に行う

## タグ修正一覧（11種類）
| 修正前 | 修正後 | 対象ファイル数 |
|---|---|---|
| `vscode` / `VScode` | `VSCode` | 7 |
| `aws` | `AWS` | 6 |
| `lambda` | `Lambda` | 2 |
| `s3` | `S3` | 2 |
| `python` | `Python` | 2 |
| `chatGPT` | `ChatGPT` | 2 |
| `seo` | `SEO` | 3 |
| `Intellij` / `intellij` | `IntelliJ` | 5 |
| `jetBrains` | `JetBrains` | 1 |
| `Github Copilot` | `GitHub Copilot` | 1 |
| `go` | `Go` | 1 |

## Test plan
- [ ] `hugo --minify` でビルドが成功すること
- [ ] タグページが正しく統合されていること（例: `/tags/vscode/` と `/tags/VSCode/` が1つになる）
- [ ] CLAUDE.mdの内容が正確であること