### PR TITLE
feat: 英語記事のSEO改善

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -24,6 +24,8 @@ images = ["images/share.webp"]
     languageName = "en-US 🇺🇸"
     LanguageCode = "en-US"
     [languages.en.params]
+    [languages.en.params.sidebar]
+      subtitle = "A blog about engineering and management by an engineering manager"
 
 
 [social]

--- a/content/blog/001-hugo-netlify-build/index.en.md
+++ b/content/blog/001-hugo-netlify-build/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Publishing a Blog with Hugo + Netlify + Github'
+description = 'How to publish a blog using Hugo, Netlify, and GitHub. A beginner-friendly guide covering static site generation, GitHub integration, Netlify deployment, and favicon setup.'
 date = 2023-12-02T00:59:37+09:00
 draft = false
 toc = true

--- a/content/blog/002-line-messaging-api/index.en.md
+++ b/content/blog/002-line-messaging-api/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Registering and Using the LINE Messaging API'
+description = 'How to register for LINE Messaging API and send messages with curl. Step-by-step guide from provider creation to channel setup and Bot messaging.'
 date = 2023-12-07T09:37:00+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/003-google-analytics/index.en.md
+++ b/content/blog/003-google-analytics/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Set Up Google Analytics with Hugo'
+description = 'How to set up Google Analytics GA4 on a Hugo blog. Covers tracking ID setup, config.toml configuration, and embedding analytics tags in templates.'
 date = 2023-12-09T18:09:42+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/004-python-setup/index.en.md
+++ b/content/blog/004-python-setup/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Setting Up a Local Environment Using Pyenv and venv'
+description = 'How to set up a Python development environment on Mac using Pyenv and venv. Covers version management, virtual environment creation, updates, and deletion.'
 date = 2023-12-10T23:19:33+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/005-github-copilot/index.en.md
+++ b/content/blog/005-github-copilot/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use GitHub Copilot in IntelliJ'
+description = 'How to use GitHub Copilot in IntelliJ. Covers plugin installation, Mac keyboard shortcuts, and code completion with comment-driven suggestions.'
 date = 2023-12-11T22:45:40+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/006-intellij-lamda-setup/index.en.md
+++ b/content/blog/006-intellij-lamda-setup/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Efficient Lambda Development with AWS Toolkit in IntelliJ'
+description = 'How to develop Lambda functions with AWS Toolkit in IntelliJ. Covers Docker and AWS CLI setup, Lambda creation, and local execution steps.'
 date = 2023-12-12T22:40:05+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/007-google-search-console/index.en.md
+++ b/content/blog/007-google-search-console/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Using Google Search Console to Make Your Blog Searchable on Google'
+description = 'How to use Google Search Console to make your blog discoverable on Google. Covers domain verification, sitemap registration, and index request steps.'
 date = 2023-12-18T19:10:04+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/008-aws-eventbrdge/index.en.md
+++ b/content/blog/008-aws-eventbrdge/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Schedule Lambda Functions with AWS EventBridge'
+description = 'How to schedule Lambda functions with AWS EventBridge. Covers cron expressions, JST timezone settings, costs, and common troubleshooting tips.'
 date = 2023-12-21T23:03:13+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/009-light-house/index.en.md
+++ b/content/blog/009-light-house/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Introduction to Using Lighthouse'
+description = 'How to use Google Lighthouse to measure blog performance. Covers Performance, Accessibility, SEO, and Best Practices scores and how to interpret them.'
 date = 2023-12-22T23:08:00+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/010-favicon/index.en.md
+++ b/content/blog/010-favicon/index.en.md
@@ -1,7 +1,8 @@
 +++
 title = 'Creating and Displaying a Favicon with Hugo'
+description = 'How to create a favicon and set it up on a Hugo blog. Covers image generation with Favicon Generator and configuration in config.toml.'
 date = 2023-12-24T22:14:39+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['Hugo', 'Favicon']
 +++

--- a/content/blog/011-hugo-multilingul-support/index.en.md
+++ b/content/blog/011-hugo-multilingul-support/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Using ChatGPT to Make a Hugo Blog Multilingual'
+description = 'How to make a Hugo blog multilingual using ChatGPT. Covers Markdown translation prompts, config.toml settings, and directory structure for i18n support.'
 date = 2023-12-31T20:46:36+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/012-social-card/index.en.md
+++ b/content/blog/012-social-card/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Setting Up Twitter Social Cards'
+description = 'How to set up Twitter Social Cards for a Hugo blog. Covers Summary Card vs Large Image types, theme-specific settings, and debugging tools.'
 date = 2024-01-06T21:45:12+09:00
 draft = false
 categories = ['Blog']

--- a/content/blog/013-good-strategy-bad-strategy/index.en.md
+++ b/content/blog/013-good-strategy-bad-strategy/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Create a Product Strategy'
+description = 'How to create an effective product strategy based on "Good Strategy Bad Strategy." Covers the three core elements: diagnosis, guiding policy, and coherent actions.'
 date = 2024-01-08T21:55:15+09:00
 draft = false
 categories = ['Management']

--- a/content/blog/014-aws-apigateway-lambda/index.en.md
+++ b/content/blog/014-aws-apigateway-lambda/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Integrating AWS API Gateway with Lambda'
+description = 'How to integrate AWS API Gateway with Lambda. Covers REST API vs HTTP API selection, proxy integration setup, and trigger configuration steps.'
 date = 2024-01-13T18:06:52+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/015-s3-object-check/index.en.md
+++ b/content/blog/015-s3-object-check/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Check if an S3 Object Exists in Python boto3'
+description = 'How to check if an S3 object exists using Python boto3. Covers the recommended head_object method, resource vs client differences, and common pitfalls.'
 date = 2024-01-27T21:41:37+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/016-itilv4-availability-management/index.en.md
+++ b/content/blog/016-itilv4-availability-management/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Understanding Availability Management in ITIL v4'
+description = 'Understanding ITIL v4 availability management. Covers service availability control, analysis, improvement processes, SLA design, and dashboard examples from real experience.'
 date = 2024-01-30T20:34:58+09:00
 draft = false
 categories = ['Management']

--- a/content/blog/017-vscode-copilot/index.en.md
+++ b/content/blog/017-vscode-copilot/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Complete Guide to Using GitHub Copilot in VSCode'
+description = 'How to set up and use GitHub Copilot in VSCode. Covers extension installation, Markdown support configuration, and Chat tool usage for maximum productivity.'
 date = 2024-02-04T22:34:51+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/018-itilv4-business-analysis/index.en.md
+++ b/content/blog/018-itilv4-business-analysis/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Explaining Business Analysis in ITIL v4'
+description = 'Understanding ITIL v4 business analysis. Covers SWOT analysis, customer journey mapping, and solution identification processes with practical insights.'
 date = 2024-02-09T09:00:56+09:00
 draft = false
 categories = ['Management']

--- a/content/blog/019-stable-diffusion/index.en.md
+++ b/content/blog/019-stable-diffusion/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use Stable Diffusion Web UI on Mac'
+description = 'How to install Stable Diffusion Web UI on Mac for local image generation. Covers Python environment setup, model placement, and image generation steps.'
 date = 2024-02-12T11:24:59+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/020-itilv4-capacity-and-performance-management/index.en.md
+++ b/content/blog/020-itilv4-capacity-and-performance-management/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Explaining Capacity and Performance Management in ITIL v4'
+description = 'Understanding ITIL v4 capacity and performance management. Covers latency requirements, throughput measurement, and Dynatrace monitoring with practical examples.'
 date = 2024-02-27T08:53:36+09:00
 draft = false
 categories = ['Management']

--- a/content/blog/021-typescript-setup/index.en.md
+++ b/content/blog/021-typescript-setup/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Setting Up TypeScript Development Environment Easily with Volta'
+description = 'How to set up a TypeScript development environment on Mac with Volta. Covers Node.js installation, yarn setup, project creation, and Hello World execution.'
 date = 2024-03-10T13:11:13+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/022-typescript-enum/index.en.md
+++ b/content/blog/022-typescript-enum/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Using Enums in TypeScript'
+description = 'How to use Enums in TypeScript. Covers numeric and string enum definitions, string comparison patterns, and JavaScript compilation output examples.'
 date = 2024-03-23T13:11:13+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/023-chatgpt-create-image/index.en.md
+++ b/content/blog/023-chatgpt-create-image/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Generating Images with ChatGPT'
+description = 'How to generate images with ChatGPT Plus using DALL-E. Covers launching from Explore GPTs, prompt input examples, and refining images with follow-up instructions.'
 date = 2024-03-31T17:35:07+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/024-bluesky-api/index.en.md
+++ b/content/blog/024-bluesky-api/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Using Bluesky API for Automated Posting with Python'
+description = 'How to automate Bluesky posts using Python and AT Protocol. Covers app password generation, posting script creation, and execution steps.'
 date = 2024-04-07T23:52:09+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/025-git-ignore/index.en.md
+++ b/content/blog/025-git-ignore/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Setting Up a Global gitignore for All Projects'
+description = 'How to set up a global gitignore at ~/.config/git/ignore for all projects. Includes config examples for .idea, node_modules, and other common exclusions.'
 date = 2024-04-16T23:16:25+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/026-evernote-to-notion/index.en.md
+++ b/content/blog/026-evernote-to-notion/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Migrating from Evernote to Notion'
+description = 'How to migrate from Evernote to Notion easily. Covers the Notion import feature and tips for migrating notebooks one at a time.'
 date = 2024-04-29T19:32:38+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/027-chatgpt-4o/index.en.md
+++ b/content/blog/027-chatgpt-4o/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Introduction to ChatGPT 4o'
+description = 'Overview of OpenAI GPT-4o features. Covers real-time voice interaction, faster responses, improved multilingual support, and key upgrades from previous models.'
 date = 2024-05-14T23:22:39+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/028-scrum-ceremony/index.en.md
+++ b/content/blog/028-scrum-ceremony/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Improving Team Performance by Revisiting Scrum Ceremonies'
+description = 'How to improve team performance through Scrum ceremonies. Covers optimization tips for daily standups, sprint reviews, and backlog refinement.'
 date = 2024-11-18T09:36:05+09:00
 draft = false
 categories = ['Management']

--- a/content/blog/029-grpc/index.en.md
+++ b/content/blog/029-grpc/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Research on gRPC'
+description = 'Introduction to gRPC with Python implementation. Covers Protocol Buffers schema definition, .proto file syntax, and a hands-on Quick Start tutorial.'
 date = 2024-09-01T17:53:57+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/030-go-environment-construction/index.en.md
+++ b/content/blog/030-go-environment-construction/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Setting Up a Go Development Environment on Mac and Running Hello World'
+description = 'How to set up a Go development environment on Mac. Covers Homebrew installation, Hello World program creation, execution, and binary build steps.'
 date = 2024-09-15T16:52:04+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/031-read-parquet-file/index.en.md
+++ b/content/blog/031-read-parquet-file/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Read Parquet Files on macOS'
+description = 'How to read Parquet files on macOS from the command line. Covers parquet-cli installation and usage of meta, head, and schema commands.'
 date = 2024-09-15T16:52:04+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/032-python-uv/index.en.md
+++ b/content/blog/032-python-uv/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = "Setting Up a Python Development Environment on Mac with UV"
+description = 'How to set up a Python environment on Mac with uv, a fast Rust-based package manager. Covers installation, virtual environment creation, and package management.'
 date = 2025-01-01T14:39:53+09:00
 draft = false
 categories = ["Engineering"]

--- a/content/blog/033-feast-tutorial/index.en.md
+++ b/content/blog/033-feast-tutorial/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Running the Feast Tutorial on macOS'
+description = 'How to set up Feast Feature Store on macOS. Covers installation, UI launch, training data retrieval, and materialization to the online store.'
 date = 2025-01-13T11:49:53+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/034-jetbrains-update/index.en.md
+++ b/content/blog/034-jetbrains-update/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Upgrade JetBrains Products to a Major Version'
+description = 'How to upgrade JetBrains products like IntelliJ and PyCharm to a major version. Use JetBrains Toolbox App to update while preserving settings.'
 date = 2025-06-12T20:46:53+09:00
 draft = false
 +++

--- a/content/blog/035-github-copilot-markdown/index.en.md
+++ b/content/blog/035-github-copilot-markdown/index.en.md
@@ -1,7 +1,8 @@
 +++
 title = 'How to Enable GitHub Copilot for Markdown'
+description = 'How to enable GitHub Copilot suggestions for Markdown files in VSCode. A quick settings change to boost your Markdown editing productivity.'
 date = 2025-07-21T10:00:00+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['GitHub Copilot', 'Markdown', 'VSCode']
 +++

--- a/content/blog/036-vscode-indent/index.en.md
+++ b/content/blog/036-vscode-indent/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Customize Indent Guides in VSCode'
+description = 'How to customize VSCode indent guide colors in settings. Change indent colors by depth level without extensions to improve code readability.'
 date = 2025-07-22T21:01:13+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/037-gemini-cli/index.en.md
+++ b/content/blog/037-gemini-cli/index.en.md
@@ -1,7 +1,8 @@
 +++
 title = 'How to Set Up Gemini CLI on Mac'
+description = 'How to install Gemini CLI on Mac with Homebrew and use Google Gemini AI from the terminal. Covers setup, Google account linking, and code generation.'
 date = 2025-07-22T23:21:19+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['Gemini CLI', 'AI']
 +++

--- a/content/blog/039-aws-toolkit-vscode/index.en.md
+++ b/content/blog/039-aws-toolkit-vscode/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use AWS Toolkit in Visual Studio Code'
+description = 'How to install AWS Toolkit in VSCode and configure Tokyo region (ap-northeast-1). Covers AWS Explorer region switching steps.'
 date = 2025-08-11T20:33:30+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/040-redis-local/index.en.md
+++ b/content/blog/040-redis-local/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Run Redis with Docker'
+description = 'How to run Redis with Docker. Covers container setup for the in-memory database, basic operations, connection testing, and container cleanup.'
 date = 2025-10-03T07:29:31+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/041-redis-go/index.en.md
+++ b/content/blog/041-redis-go/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use Redis with Go'
+description = 'How to use Redis with Go. Covers go-redis library setup, connection, data read/write operations, and basic commands with sample code.'
 date = 2025-10-05T20:25:02+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/042-github-copilot/index.en.md
+++ b/content/blog/042-github-copilot/index.en.md
@@ -1,7 +1,8 @@
 +++
 title = 'How to Use GitHub Copilot More Effectively with Chat Tools'
+description = 'How to use GitHub Copilot Chat tools in VSCode for better productivity. Covers codebase search, selection, terminal commands, and web page fetching.'
 date = 2025-10-07T08:39:41+09:00
-draft = true
+draft = false
 categories = ['Engineering']
 tags = ['GitHub Copilot', 'VSCode', 'Chat tool']
 +++

--- a/content/blog/043-codex/index.en.md
+++ b/content/blog/043-codex/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use Codex CLI'
+description = 'How to install and use Codex CLI. Covers npm and Homebrew installation, sign-in process, basic commands, and local development workflow.'
 date = 2025-12-12T10:00:00+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/044-openai-response-api/index.en.md
+++ b/content/blog/044-openai-response-api/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'How to Use the OpenAI Response API'
+description = 'How to use the OpenAI Response API. Covers API key setup, Python text generation, and tool calling with minimal code examples to get started.'
 date = 2025-12-24T10:00:00+09:00
 draft = false
 categories = ['Engineering']

--- a/content/blog/046-clean-bot-technical/index.en.md
+++ b/content/blog/046-clean-bot-technical/index.en.md
@@ -1,5 +1,6 @@
 +++
 title = 'Building a Cleaning Reminder Bot with AWS Lambda + LINE'
+description = 'Building a cleaning reminder LINE Bot with AWS Lambda, API Gateway, S3, and EventBridge. Covers SAM serverless architecture and Python implementation details.'
 date = 2026-02-07T19:00:00+09:00
 draft = false
 categories = ['Engineering']


### PR DESCRIPTION
## Summary

- 英語記事44本にSEO用の `description` メタタグを追加（46本中2本は既存）
- 下書きのまま非公開だった英語記事4本を公開（010, 035, 037, 042）
- 英語ページのサイドバー字幕を英語化

## Background

英語記事のアクセスがほぼゼロの原因を調査した結果、以下の問題を特定:
1. 48本中46本の英語記事に `description` がなく、Google検索結果にスニペットが表示されない
2. 4本の英語記事が `draft = true` のまま非公開
3. 英語ページのサイドバーが日本語のまま

## Changes (45 files, +50 -4)

| 変更内容 | 対象 |
|---------|------|
| `description` 追加 | 44 `index.en.md` ファイル |
| `draft = false` + `description` 追加 | 4 `index.en.md` ファイル (010, 035, 037, 042) |
| English sidebar subtitle 追加 | `config/_default/config.toml` |

## Test plan

- [x] `hugo --minify` ビルド成功（EN 211ページ / JP 218ページ）
- [x] HTML出力に meta description が正しく反映（OGP、Twitter Card、JSON-LD含む）
- [x] 英語サイドバーに英語字幕が表示される
- [x] 下書きの英語記事が残っていないことを確認
- [ ] デプロイ後に Google Search Console でインデックス状況を確認