### PR TITLE
feat: GitHub Pagesへの移行準備

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.120.3'
           extended: true
 
       - name: Build
@@ -32,3 +32,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
+          cname: bossagyu.com

--- a/docs/plans/2026-02-22-github-pages-migration-design.md
+++ b/docs/plans/2026-02-22-github-pages-migration-design.md
@@ -1,0 +1,62 @@
+# GitHub Pages Migration Design
+
+## Problem
+
+bossagyu.com is hosted on Netlify (free plan) with only 6 CDN POPs worldwide. US and other international visitors experience slow load times, negatively impacting SEO and user experience. Netlify-specific features (redirects, forms, functions) are not used.
+
+## Decision
+
+Migrate hosting from Netlify to GitHub Pages (Fastly CDN, 80+ POPs). The GitHub Actions deployment pipeline already exists (`gh-pages.yml`).
+
+## Trade-offs Accepted
+
+- **HTTP header customization not available**: GitHub Pages serves all assets with `Cache-Control: max-age=600` (10 min). Cannot set long cache times for fingerprinted assets or security headers (CSP, X-Frame-Options). Accepted because CDN performance gain outweighs caching limitation for a personal blog.
+- **No deploy previews**: PR preview URLs will not be generated. Accepted for a single-author blog.
+- **No one-click rollback**: Must redeploy via GitHub Actions. Accepted as rollback is still fast.
+- **HTTPS gap during migration**: 5-60 minute window where HSTS-enforced browsers may see errors. Mitigated by migrating during low-traffic hours.
+
+## Code Changes
+
+### 1. Add CNAME parameter to GitHub Actions workflow
+
+Add `cname: bossagyu.com` to the peaceiris/actions-gh-pages deploy step. Without this, every deployment overwrites the gh-pages branch and removes the CNAME file, causing the custom domain to reset.
+
+### 2. Update Hugo version in workflow
+
+Update `hugo-version` from `0.119.0` to `0.120.3` to match `netlify.toml` and ensure build parity.
+
+## DNS Migration (Manual)
+
+### Pre-migration
+- Verify GitHub Pages works at bossagyu.github.io/my-blog/
+- Merge code changes (CNAME + Hugo version) to main
+- Verify deployment succeeds with CNAME file in gh-pages branch
+
+### Migration Day (low-traffic hours)
+1. GitHub Settings > Pages: set custom domain to `bossagyu.com`
+2. Netlify DNS: delete old A records (52.74.6.109, 13.215.239.219)
+3. Netlify DNS: add A records for GitHub Pages (185.199.108-111.153)
+4. Netlify DNS: add AAAA records for IPv6
+5. Netlify DNS: change www to CNAME `bossagyu.github.io`
+6. Wait for DNS propagation (~2-5 min, TTL is already 120s)
+7. Wait for HTTPS certificate provisioning (5-60 min)
+8. Enable "Enforce HTTPS" in GitHub Pages settings
+9. Test all pages (JP, EN, aliases)
+
+### Post-migration
+- Keep Netlify site active for 48h as fallback
+- Resubmit sitemap in Google Search Console
+- Monitor crawl stats for 2 weeks
+- Optionally increase DNS TTL to 3600s
+
+## Rollback Plan
+
+Revert Netlify DNS A records to original IPs. Propagation ~2 min (TTL 120s). Keep Netlify site active until confirmed stable.
+
+## Success Criteria
+
+- `curl -I https://bossagyu.com` shows GitHub Pages headers (no `server: Netlify`)
+- HTTPS works with valid certificate
+- All JP and EN pages load correctly
+- Hugo alias redirects work
+- www redirects to apex domain

--- a/docs/plans/2026-02-22-github-pages-migration-plan.md
+++ b/docs/plans/2026-02-22-github-pages-migration-plan.md
@@ -1,0 +1,150 @@
+# GitHub Pages Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prepare the repository for GitHub Pages hosting by adding CNAME support and updating Hugo version, enabling DNS migration from Netlify.
+
+**Architecture:** Two changes to `.github/workflows/gh-pages.yml`: add `cname` parameter to preserve custom domain across deploys, and update Hugo version to 0.120.3 for build parity. DNS migration is a manual step documented in the design doc.
+
+**Tech Stack:** GitHub Actions, peaceiris/actions-gh-pages, Hugo 0.120.3
+
+---
+
+### Task 1: Update GitHub Actions workflow
+
+**Files:**
+- Modify: `.github/workflows/gh-pages.yml:21-34`
+
+**Step 1: Update Hugo version**
+
+Change line 23 from:
+```yaml
+          hugo-version: '0.119.0'
+```
+To:
+```yaml
+          hugo-version: '0.120.3'
+```
+
+**Step 2: Add CNAME parameter to Deploy step**
+
+Add `cname: bossagyu.com` to the Deploy step's `with` block. Change lines 30-34 from:
+```yaml
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+```
+To:
+```yaml
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          cname: bossagyu.com
+```
+
+**Step 3: Verify Hugo build locally**
+
+Run: `hugo --minify`
+Expected: Build succeeds without errors (211 EN / 218 JP pages)
+
+**Step 4: Commit**
+
+```bash
+git add .github/workflows/gh-pages.yml
+git commit -m "feat: add CNAME for GitHub Pages and update Hugo to 0.120.3"
+```
+
+---
+
+### Task 2: Verify deployment pipeline
+
+**Step 1: Push branch and create PR**
+
+```bash
+git push -u origin feat/github-pages-migration
+gh pr create --title "feat: GitHub Pagesへの移行準備" --body "..."
+```
+
+**Step 2: Verify GitHub Actions build succeeds**
+
+Check the PR's Actions tab. Expected: Build succeeds (Hugo 0.120.3).
+
+**Step 3: Merge PR**
+
+After build passes, merge to main.
+
+**Step 4: Verify CNAME file in gh-pages branch**
+
+After the main branch deploys:
+```bash
+gh api repos/bossagyu/my-blog/contents/CNAME?ref=gh-pages
+```
+Expected: CNAME file exists with content `bossagyu.com`
+
+---
+
+### Task 3: DNS Migration (Manual — documented for reference)
+
+This task is performed manually in the Netlify DNS dashboard and GitHub Settings. Not automatable via code.
+
+**Step 1: Pre-configure GitHub Pages custom domain**
+
+Go to GitHub repo Settings > Pages > Custom domain: enter `bossagyu.com`. It will fail DNS check — that's expected.
+
+**Step 2: Update DNS records in Netlify DNS**
+
+Delete existing A records:
+- `52.74.6.109`
+- `13.215.239.219`
+
+Add GitHub Pages A records:
+- `185.199.108.153`
+- `185.199.109.153`
+- `185.199.110.153`
+- `185.199.111.153`
+
+Add AAAA records (IPv6):
+- `2606:50c0:8000::153`
+- `2606:50c0:8001::153`
+- `2606:50c0:8002::153`
+- `2606:50c0:8003::153`
+
+Change www record:
+- Type: CNAME
+- Value: `bossagyu.github.io`
+
+**Step 3: Verify DNS propagation**
+
+Run: `dig bossagyu.com +short`
+Expected: GitHub Pages IPs (185.199.108-111.153)
+
+**Step 4: Wait for HTTPS certificate**
+
+Check GitHub Pages settings for the green checkmark. Takes 5-60 minutes.
+Enable "Enforce HTTPS" once available.
+
+**Step 5: Verify site**
+
+```bash
+curl -sI https://bossagyu.com | head -5
+```
+Expected: HTTP/2 200, no `server: Netlify` header
+
+Test pages:
+- https://bossagyu.com/ (JP home)
+- https://bossagyu.com/en/ (EN home)
+- https://bossagyu.com/blog/001-hugo-netlify-build/ (article)
+- https://bossagyu.com/blog/010-favicon/ (alias redirect)
+- https://www.bossagyu.com/ (www redirect)
+
+**Step 6: Post-migration**
+
+- Resubmit sitemap in Google Search Console
+- Keep Netlify site active for 48 hours
+- Monitor for 404s or certificate errors


### PR DESCRIPTION
## Summary

- GitHub Actionsワークフローに `cname: bossagyu.com` を追加（デプロイ時にCNAMEファイルを自動生成）
- Hugo バージョンを 0.119.0 → 0.120.3 に更新（netlify.tomlと統一）
- 移行の設計・実装計画ドキュメントを追加

## Background

bossagyu.com は現在 Netlify（Standard CDN、6拠点）で配信中。GitHub Pages（Fastly CDN、80+ POP）に移行することで、米国を含む海外からのアクセス速度を改善し、英語記事のSEOを向上させる。

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `.github/workflows/gh-pages.yml` | `cname: bossagyu.com` 追加、Hugo 0.120.3 に更新 |
| `docs/plans/2026-02-22-github-pages-migration-design.md` | 設計ドキュメント |
| `docs/plans/2026-02-22-github-pages-migration-plan.md` | 実装計画 |

## Test plan

- [x] `hugo --minify` ビルド成功（211 EN / 218 JP pages）
- [ ] GitHub Actions ビルド成功を確認
- [ ] マージ後、gh-pages ブランチに CNAME ファイルが存在することを確認
- [ ] DNS切替後、`curl -sI https://bossagyu.com` で GitHub Pages からの配信を確認