### PR TITLE
chore: Netlify設定ファイルの削除とデプロイ情報の更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,10 @@ Hugo設定は `config/_default/` に分割:
 
 ## デプロイ
 
-- **GitHub Pages**（メイン）: `main`へのプッシュでGitHub Actionsが実行、Hugo 0.119.0 extended、`gh-pages`ブランチにデプロイ
-- **Netlify**（サブ）: Hugo 0.120.3、`public/`を公開
+- **GitHub Pages**: `main`へのプッシュでGitHub Actionsが実行、Hugo 0.120.3 extended、`gh-pages`ブランチにデプロイ
+- CDN: Fastly（80+ POP worldwide）
+- カスタムドメイン: bossagyu.com（Netlify DNS で A/AAAA レコード管理）
+- HTTPS: GitHub Pages 自動管理（Let's Encrypt）
 
 ## Gitワークフロー
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[build]
-command = "hugo"
-publish = "public"
-
-[build.environment]
-HUGO_VERSION = "v0.120.3"


### PR DESCRIPTION
## Summary
- GitHub Pagesへの移行完了（2026-02-22）に伴い、不要になった`netlify.toml`を削除
- `CLAUDE.md`のデプロイセクションをGitHub Pages（Fastly CDN）の情報に更新

## Test plan
- [ ] Hugo buildが正常に完了すること（netlify.tomlはGitHub Actions未使用）
- [ ] サイトが正常にデプロイされること