### PR TITLE
fix: 050記事のquadrantChart構文エラーを修正

### DIFF
--- a/content/blog/050-skill-proficiency-stages/index.en.md
+++ b/content/blog/050-skill-proficiency-stages/index.en.md
@@ -125,8 +125,8 @@ The four stages can be organized as a 2x2 matrix.
 ```mermaid
 quadrantChart
     title Four Stages of Competence
-    x-axis "Low capability" --> "High capability"
-    y-axis "Unaware" --> "Aware"
+    x-axis Low capability --> High capability
+    y-axis Unaware --> Aware
     quadrant-1 Conscious Competence
     quadrant-2 Conscious Incompetence
     quadrant-3 Unconscious Incompetence

--- a/content/blog/050-skill-proficiency-stages/index.md
+++ b/content/blog/050-skill-proficiency-stages/index.md
@@ -127,12 +127,12 @@ flowchart LR
 ```mermaid
 quadrantChart
     title 意識的能力の4段階
-    x-axis "能力が低い" --> "能力が高い"
-    y-axis "自覚していない" --> "自覚している"
-    quadrant-1 Conscious Competence / 意識的有能
-    quadrant-2 Conscious Incompetence / 意識的無能
-    quadrant-3 Unconscious Incompetence / 無意識的無能
-    quadrant-4 Unconscious Competence / 無意識的有能
+    x-axis 能力が低い --> 能力が高い
+    y-axis 自覚していない --> 自覚している
+    quadrant-1 意識的有能
+    quadrant-2 意識的無能
+    quadrant-3 無意識的無能
+    quadrant-4 無意識的有能
 ```
 
 **1. Unconscious Incompetence（無意識的無能）**


### PR DESCRIPTION
## Summary
- JP版の \`quadrantChart\` で \`/\` 区切りのbilingualラベル（例: \`Conscious Competence / 意識的有能\`）がMermaidパーサーで構文エラーを起こしていたため、quadrant-1〜4 を日本語のみに変更
- 併せて x-axis / y-axis の引用符を削除（Mermaid公式ドキュメントの例では引用符を使っていないため）
- EN版にも同じ引用符削除を適用（パーサー互換性の予防措置）

## 原因
Mermaid の \`quadrantChart\` の \`quadrant-N <text>\` 構文では、\`<text>\` は行末までの自由テキストとして扱われるが、\`/\` を挟んだ bilingual ラベル＋日本語UTF-8混在でパーサーが構文エラーになっていた。

## Test plan
- [x] \`hugo --quiet\` で警告・エラーなし
- [ ] マージ後、本番デプロイで \`https://bossagyu.com/blog/050-skill-proficiency-stages/\` のMermaid図が正しくレンダリングされることを確認
- [ ] 英語版も同様に確認