### PR TITLE
fix: JP版quadrantChartの日本語に引用符を追加（再修正）

### DIFF
--- a/content/blog/050-skill-proficiency-stages/index.md
+++ b/content/blog/050-skill-proficiency-stages/index.md
@@ -127,12 +127,12 @@ flowchart LR
 ```mermaid
 quadrantChart
     title 意識的能力の4段階
-    x-axis 能力が低い --> 能力が高い
-    y-axis 自覚していない --> 自覚している
-    quadrant-1 意識的有能
-    quadrant-2 意識的無能
-    quadrant-3 無意識的無能
-    quadrant-4 無意識的有能
+    x-axis "能力が低い" --> "能力が高い"
+    y-axis "自覚していない" --> "自覚している"
+    quadrant-1 "意識的有能"
+    quadrant-2 "意識的無能"
+    quadrant-3 "無意識的無能"
+    quadrant-4 "無意識的有能"
 ```
 
 **1. Unconscious Incompetence（無意識的無能）**


### PR DESCRIPTION
## Summary

前回のPR #21 でquadrantChartの引用符をすべて外したが、JP版の日本語テキストは引用符なしだとMermaidパーサーで Lexical error になることが判明したため再修正。

## 検証方法
`@mermaid-js/mermaid-cli` をローカルで使って実際にレンダリングを試行:

| パターン | 結果 |
|---------|------|
| 全て引用符なし（前回PR #21） | ❌ Lexical error on line 3 |
| title のみ引用符なし、axes/quadrants に引用符 | ✅ 正しくレンダリング |
| title に引用符 | ⚠️ 引用符が表示に含まれる |

## 正しい構文
- `title`: 引用符なし（引用符を付けると表示に含まれる）
- `x-axis` / `y-axis`: 日本語などマルチバイト文字を使う場合は引用符必須
- `quadrant-1`〜`quadrant-4`: 同上、日本語には引用符必須

EN版は ASCII のみなので引用符不要（現状のまま）。

## Test plan
- [x] `hugo --quiet` で警告・エラーなし
- [x] `mermaid-cli` によるローカル検証で正しくSVG生成
- [ ] マージ後、本番デプロイで確認