### PR TITLE
feat: Milvusアーキテクチャ解説記事を追加（052）

### DIFF
--- a/content/blog/052-milvus-architecture/img-052-001-en.svg
+++ b/content/blog/052-milvus-architecture/img-052-001-en.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 560" font-family="sans-serif">
+  <rect width="760" height="560" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+  </defs>
+
+  <!-- client -->
+  <rect x="270" y="14" width="220" height="38" rx="6" fill="#2c3e50"/>
+  <text x="380" y="38" text-anchor="middle" font-size="14" fill="#ffffff">Client (SDK / API)</text>
+  <line x1="380" y1="52" x2="380" y2="76" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- access layer -->
+  <rect x="100" y="80" width="640" height="84" rx="8" fill="#eaf2fb" stroke="#b9d0e8"/>
+  <text x="50" y="112" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Access</text>
+  <text x="50" y="130" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Layer</text>
+  <rect x="180" y="96" width="170" height="52" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="265" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="265" y="136" text-anchor="middle" font-size="11" fill="#555">stateless</text>
+  <rect x="420" y="96" width="170" height="52" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="505" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="505" y="136" text-anchor="middle" font-size="11" fill="#555">validation / result merge</text>
+  <line x1="380" y1="164" x2="380" y2="188" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- coordinator -->
+  <rect x="100" y="192" width="640" height="76" rx="8" fill="#fdf3e7" stroke="#ecd3ae"/>
+  <text x="50" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Control</text>
+  <text x="50" y="240" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Plane</text>
+  <rect x="230" y="206" width="300" height="48" rx="6" fill="#ffffff" stroke="#e67e22" stroke-width="1.5"/>
+  <text x="380" y="226" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Coordinator (brain of the cluster)</text>
+  <text x="380" y="244" text-anchor="middle" font-size="11" fill="#555">DDL/DCL, TSO, scheduling, load balancing</text>
+  <line x1="380" y1="268" x2="380" y2="292" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- worker nodes -->
+  <rect x="100" y="296" width="640" height="110" rx="8" fill="#eafaf1" stroke="#b8e0c8"/>
+  <text x="50" y="344" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Worker</text>
+  <text x="50" y="362" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Nodes</text>
+  <rect x="120" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="215" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="215" y="354" text-anchor="middle" font-size="11" fill="#555">real-time writes</text>
+  <text x="215" y="370" text-anchor="middle" font-size="11" fill="#555">search on growing data</text>
+  <rect x="330" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="425" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Query Node</text>
+  <text x="425" y="354" text-anchor="middle" font-size="11" fill="#555">search on persisted</text>
+  <text x="425" y="370" text-anchor="middle" font-size="11" fill="#555">(historical) data</text>
+  <rect x="540" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="635" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Data Node</text>
+  <text x="635" y="354" text-anchor="middle" font-size="11" fill="#555">compaction</text>
+  <text x="635" y="370" text-anchor="middle" font-size="11" fill="#555">index building</text>
+  <line x1="215" y1="406" x2="215" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="425" y1="406" x2="425" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="635" y1="406" x2="635" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- storage layer -->
+  <rect x="100" y="434" width="640" height="110" rx="8" fill="#f4eefb" stroke="#d6c4ec"/>
+  <text x="50" y="482" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Storage</text>
+  <text x="50" y="500" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Layer</text>
+  <rect x="120" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="215" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">WAL Storage</text>
+  <text x="215" y="492" text-anchor="middle" font-size="11" fill="#555">Woodpecker /</text>
+  <text x="215" y="508" text-anchor="middle" font-size="11" fill="#555">Kafka / Pulsar</text>
+  <rect x="330" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="425" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage</text>
+  <text x="425" y="492" text-anchor="middle" font-size="11" fill="#555">S3 / MinIO /</text>
+  <text x="425" y="508" text-anchor="middle" font-size="11" fill="#555">Azure Blob</text>
+  <rect x="540" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="635" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Meta Storage</text>
+  <text x="635" y="492" text-anchor="middle" font-size="11" fill="#555">etcd</text>
+  <text x="635" y="508" text-anchor="middle" font-size="11" fill="#555">metadata / service registry</text>
+</svg>

--- a/content/blog/052-milvus-architecture/img-052-001.svg
+++ b/content/blog/052-milvus-architecture/img-052-001.svg
@@ -19,7 +19,7 @@
   <text x="265" y="136" text-anchor="middle" font-size="11" fill="#555">ステートレス</text>
   <rect x="420" y="96" width="170" height="52" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
   <text x="505" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
-  <text x="505" y="136" text-anchor="middle" font-size="11" fill="#555">リクエスト検証・結果の集約</text>
+  <text x="505" y="136" text-anchor="middle" font-size="11" fill="#555">検証・結果の集約</text>
   <line x1="380" y1="164" x2="380" y2="188" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
 
   <!-- coordinator -->

--- a/content/blog/052-milvus-architecture/img-052-001.svg
+++ b/content/blog/052-milvus-architecture/img-052-001.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 560" font-family="sans-serif">
+  <rect width="760" height="560" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+  </defs>
+
+  <!-- client -->
+  <rect x="270" y="14" width="220" height="38" rx="6" fill="#2c3e50"/>
+  <text x="380" y="38" text-anchor="middle" font-size="14" fill="#ffffff">クライアント（SDK / API）</text>
+  <line x1="380" y1="52" x2="380" y2="76" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- access layer -->
+  <rect x="100" y="80" width="640" height="84" rx="8" fill="#eaf2fb" stroke="#b9d0e8"/>
+  <text x="50" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">アクセス層</text>
+  <rect x="180" y="96" width="170" height="52" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="265" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="265" y="136" text-anchor="middle" font-size="11" fill="#555">ステートレス</text>
+  <rect x="420" y="96" width="170" height="52" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="505" y="118" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="505" y="136" text-anchor="middle" font-size="11" fill="#555">リクエスト検証・結果の集約</text>
+  <line x1="380" y1="164" x2="380" y2="188" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- coordinator -->
+  <rect x="100" y="192" width="640" height="76" rx="8" fill="#fdf3e7" stroke="#ecd3ae"/>
+  <text x="50" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">制御</text>
+  <text x="50" y="240" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">プレーン</text>
+  <rect x="230" y="206" width="300" height="48" rx="6" fill="#ffffff" stroke="#e67e22" stroke-width="1.5"/>
+  <text x="380" y="226" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Coordinator（クラスタの頭脳）</text>
+  <text x="380" y="244" text-anchor="middle" font-size="11" fill="#555">DDL/DCL・TSO・スケジューリング・負荷分散</text>
+  <line x1="380" y1="268" x2="380" y2="292" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- worker nodes -->
+  <rect x="100" y="296" width="640" height="110" rx="8" fill="#eafaf1" stroke="#b8e0c8"/>
+  <text x="50" y="344" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">ワーカー</text>
+  <text x="50" y="362" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">ノード</text>
+  <rect x="120" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="215" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="215" y="354" text-anchor="middle" font-size="11" fill="#555">リアルタイム書き込み</text>
+  <text x="215" y="370" text-anchor="middle" font-size="11" fill="#555">増分データの検索</text>
+  <rect x="330" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="425" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Query Node</text>
+  <text x="425" y="354" text-anchor="middle" font-size="11" fill="#555">永続化済みデータの</text>
+  <text x="425" y="370" text-anchor="middle" font-size="11" fill="#555">検索</text>
+  <rect x="540" y="312" width="190" height="78" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="635" y="334" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Data Node</text>
+  <text x="635" y="354" text-anchor="middle" font-size="11" fill="#555">コンパクション</text>
+  <text x="635" y="370" text-anchor="middle" font-size="11" fill="#555">インデックス構築</text>
+  <line x1="215" y1="406" x2="215" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="425" y1="406" x2="425" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="635" y1="406" x2="635" y2="430" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- storage layer -->
+  <rect x="100" y="434" width="640" height="110" rx="8" fill="#f4eefb" stroke="#d6c4ec"/>
+  <text x="50" y="482" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">ストレージ</text>
+  <text x="50" y="500" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">層</text>
+  <rect x="120" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="215" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">WAL Storage</text>
+  <text x="215" y="492" text-anchor="middle" font-size="11" fill="#555">Woodpecker /</text>
+  <text x="215" y="508" text-anchor="middle" font-size="11" fill="#555">Kafka / Pulsar</text>
+  <rect x="330" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="425" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage</text>
+  <text x="425" y="492" text-anchor="middle" font-size="11" fill="#555">S3 / MinIO /</text>
+  <text x="425" y="508" text-anchor="middle" font-size="11" fill="#555">Azure Blob</text>
+  <rect x="540" y="450" width="190" height="78" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="635" y="472" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Meta Storage</text>
+  <text x="635" y="492" text-anchor="middle" font-size="11" fill="#555">etcd</text>
+  <text x="635" y="508" text-anchor="middle" font-size="11" fill="#555">メタデータ・サービス登録</text>
+</svg>

--- a/content/blog/052-milvus-architecture/img-052-002-en.svg
+++ b/content/blog/052-milvus-architecture/img-052-002-en.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 430" font-family="sans-serif">
+  <rect width="760" height="430" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+  </defs>
+
+  <!-- top row: write path -->
+  <rect x="20" y="44" width="110" height="56" rx="6" fill="#2c3e50"/>
+  <text x="75" y="68" text-anchor="middle" font-size="13" fill="#ffffff">Client</text>
+  <text x="75" y="86" text-anchor="middle" font-size="11" fill="#d0d7de">Insert / Delete</text>
+  <line x1="130" y1="72" x2="166" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+
+  <rect x="170" y="44" width="150" height="56" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="245" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="245" y="84" text-anchor="middle" font-size="11" fill="#555">splits data by shard</text>
+  <circle cx="182" cy="38" r="11" fill="#e74c3c"/>
+  <text x="182" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">1</text>
+  <line x1="320" y1="72" x2="356" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="338" y="60" text-anchor="middle" font-size="11" fill="#555">vchannel</text>
+
+  <rect x="360" y="44" width="180" height="56" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="450" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="450" y="84" text-anchor="middle" font-size="11" fill="#555">assigns TSO, checks consistency</text>
+  <circle cx="372" cy="38" r="11" fill="#e74c3c"/>
+  <text x="372" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">2</text>
+  <line x1="540" y1="72" x2="586" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="563" y="60" text-anchor="middle" font-size="11" fill="#555">append</text>
+
+  <rect x="590" y="44" width="150" height="56" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="665" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">WAL Storage</text>
+  <text x="665" y="84" text-anchor="middle" font-size="11" fill="#555">durable = write committed</text>
+  <circle cx="602" cy="38" r="11" fill="#e74c3c"/>
+  <text x="602" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">3</text>
+
+  <!-- streaming node builds growing segment -->
+  <line x1="450" y1="100" x2="450" y2="142" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="552" y="128" text-anchor="middle" font-size="11" fill="#555">applies WAL asynchronously</text>
+
+  <rect x="340" y="146" width="220" height="62" rx="6" fill="#eafaf1" stroke="#27ae60" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="450" y="170" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Growing Segment</text>
+  <text x="450" y="190" text-anchor="middle" font-size="11" fill="#555">in-memory, searchable right away</text>
+  <circle cx="352" cy="140" r="11" fill="#e74c3c"/>
+  <text x="352" y="144.5" text-anchor="middle" font-size="12" fill="#ffffff">4</text>
+
+  <line x1="450" y1="208" x2="450" y2="252" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="530" y="234" text-anchor="middle" font-size="11" fill="#555">flush (seal)</text>
+
+  <!-- object storage with sealed segments -->
+  <rect x="180" y="256" width="400" height="120" rx="8" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="380" y="280" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage (S3 / MinIO, etc.)</text>
+  <circle cx="192" cy="250" r="11" fill="#e74c3c"/>
+  <text x="192" y="254.5" text-anchor="middle" font-size="12" fill="#ffffff">5</text>
+  <rect x="210" y="296" width="160" height="60" rx="6" fill="#ffffff" stroke="#8e44ad"/>
+  <text x="290" y="320" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c3e50">Sealed Segment</text>
+  <text x="290" y="340" text-anchor="middle" font-size="11" fill="#555">immutable, persisted</text>
+  <rect x="390" y="296" width="160" height="60" rx="6" fill="#ffffff" stroke="#8e44ad"/>
+  <text x="470" y="320" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c3e50">Index</text>
+  <text x="470" y="340" text-anchor="middle" font-size="11" fill="#555">built per segment</text>
+
+  <!-- data node -->
+  <rect x="610" y="276" width="130" height="80" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="675" y="306" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Data Node</text>
+  <text x="675" y="326" text-anchor="middle" font-size="11" fill="#555">index building</text>
+  <text x="675" y="342" text-anchor="middle" font-size="11" fill="#555">compaction</text>
+  <circle cx="622" cy="270" r="11" fill="#e74c3c"/>
+  <text x="622" y="274.5" text-anchor="middle" font-size="12" fill="#ffffff">6</text>
+  <line x1="610" y1="306" x2="584" y2="306" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <line x1="584" y1="330" x2="610" y2="330" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+
+  <text x="380" y="412" text-anchor="middle" font-size="12" fill="#555">A write is committed once it is durable in the WAL, then persisted step by step: growing segment → sealed segment</text>
+</svg>

--- a/content/blog/052-milvus-architecture/img-052-002.svg
+++ b/content/blog/052-milvus-architecture/img-052-002.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 430" font-family="sans-serif">
+  <rect width="760" height="430" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+  </defs>
+
+  <!-- top row: write path -->
+  <rect x="20" y="44" width="110" height="56" rx="6" fill="#2c3e50"/>
+  <text x="75" y="68" text-anchor="middle" font-size="13" fill="#ffffff">クライアント</text>
+  <text x="75" y="86" text-anchor="middle" font-size="11" fill="#d0d7de">Insert / Delete</text>
+  <line x1="130" y1="72" x2="166" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+
+  <rect x="170" y="44" width="150" height="56" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="245" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="245" y="84" text-anchor="middle" font-size="11" fill="#555">シャード単位に分割</text>
+  <circle cx="182" cy="38" r="11" fill="#e74c3c"/>
+  <text x="182" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">1</text>
+  <line x1="320" y1="72" x2="356" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="338" y="60" text-anchor="middle" font-size="11" fill="#555">vchannel</text>
+
+  <rect x="360" y="44" width="180" height="56" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="450" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="450" y="84" text-anchor="middle" font-size="11" fill="#555">TSO付与・整合性チェック</text>
+  <circle cx="372" cy="38" r="11" fill="#e74c3c"/>
+  <text x="372" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">2</text>
+  <line x1="540" y1="72" x2="586" y2="72" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="563" y="60" text-anchor="middle" font-size="11" fill="#555">追記</text>
+
+  <rect x="590" y="44" width="150" height="56" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="665" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">WAL Storage</text>
+  <text x="665" y="84" text-anchor="middle" font-size="11" fill="#555">永続化されたら書き込み成功</text>
+  <circle cx="602" cy="38" r="11" fill="#e74c3c"/>
+  <text x="602" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">3</text>
+
+  <!-- streaming node builds growing segment -->
+  <line x1="450" y1="100" x2="450" y2="142" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="540" y="128" text-anchor="middle" font-size="11" fill="#555">WALを非同期に反映</text>
+
+  <rect x="340" y="146" width="220" height="62" rx="6" fill="#eafaf1" stroke="#27ae60" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="450" y="170" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Growing Segment</text>
+  <text x="450" y="190" text-anchor="middle" font-size="11" fill="#555">メモリ上の増分データ（即検索可能）</text>
+  <circle cx="352" cy="140" r="11" fill="#e74c3c"/>
+  <text x="352" y="144.5" text-anchor="middle" font-size="12" fill="#ffffff">4</text>
+
+  <line x1="450" y1="208" x2="450" y2="252" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <text x="545" y="234" text-anchor="middle" font-size="11" fill="#555">Flush（シール処理）</text>
+
+  <!-- object storage with sealed segments -->
+  <rect x="180" y="256" width="400" height="120" rx="8" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="380" y="280" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage（S3 / MinIO など）</text>
+  <circle cx="192" cy="250" r="11" fill="#e74c3c"/>
+  <text x="192" y="254.5" text-anchor="middle" font-size="12" fill="#ffffff">5</text>
+  <rect x="210" y="296" width="160" height="60" rx="6" fill="#ffffff" stroke="#8e44ad"/>
+  <text x="290" y="320" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c3e50">Sealed Segment</text>
+  <text x="290" y="340" text-anchor="middle" font-size="11" fill="#555">不変・永続化済み</text>
+  <rect x="390" y="296" width="160" height="60" rx="6" fill="#ffffff" stroke="#8e44ad"/>
+  <text x="470" y="320" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c3e50">インデックス</text>
+  <text x="470" y="340" text-anchor="middle" font-size="11" fill="#555">セグメントごとに構築</text>
+
+  <!-- data node -->
+  <rect x="610" y="276" width="130" height="80" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="675" y="306" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Data Node</text>
+  <text x="675" y="326" text-anchor="middle" font-size="11" fill="#555">インデックス構築</text>
+  <text x="675" y="342" text-anchor="middle" font-size="11" fill="#555">コンパクション</text>
+  <circle cx="622" cy="270" r="11" fill="#e74c3c"/>
+  <text x="622" y="274.5" text-anchor="middle" font-size="12" fill="#ffffff">6</text>
+  <line x1="610" y1="306" x2="584" y2="306" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+  <line x1="584" y1="330" x2="610" y2="330" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow2)"/>
+
+  <text x="380" y="412" text-anchor="middle" font-size="12" fill="#555">書き込みはWALへの永続化で確定し、Growing Segment → Sealed Segment へと段階的に永続化される</text>
+</svg>

--- a/content/blog/052-milvus-architecture/img-052-002.svg
+++ b/content/blog/052-milvus-architecture/img-052-002.svg
@@ -30,7 +30,7 @@
 
   <rect x="590" y="44" width="150" height="56" rx="6" fill="#ffffff" stroke="#8e44ad" stroke-width="1.5"/>
   <text x="665" y="66" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">WAL Storage</text>
-  <text x="665" y="84" text-anchor="middle" font-size="11" fill="#555">永続化されたら書き込み成功</text>
+  <text x="665" y="84" text-anchor="middle" font-size="11" fill="#555">永続化＝書き込み成功</text>
   <circle cx="602" cy="38" r="11" fill="#e74c3c"/>
   <text x="602" y="42.5" text-anchor="middle" font-size="12" fill="#ffffff">3</text>
 

--- a/content/blog/052-milvus-architecture/img-052-003-en.svg
+++ b/content/blog/052-milvus-architecture/img-052-003-en.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 410" font-family="sans-serif">
+  <rect width="760" height="410" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow3" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+    <marker id="arrow3r" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#27ae60"/>
+    </marker>
+  </defs>
+
+  <!-- client -->
+  <rect x="320" y="14" width="120" height="40" rx="6" fill="#2c3e50"/>
+  <text x="380" y="39" text-anchor="middle" font-size="13" fill="#ffffff">Client</text>
+  <line x1="360" y1="54" x2="360" y2="88" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="400" y1="88" x2="400" y2="54" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="290" y="76" text-anchor="middle" font-size="11" fill="#555">search request</text>
+  <text x="455" y="76" text-anchor="middle" font-size="11" fill="#27ae60">final result</text>
+
+  <!-- proxy -->
+  <rect x="290" y="92" width="180" height="56" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="380" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="380" y="132" text-anchor="middle" font-size="11" fill="#555">fan-out to shards, merge results</text>
+
+  <!-- branches -->
+  <line x1="320" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="225" y1="194" x2="350" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <line x1="440" y1="148" x2="575" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="535" y1="194" x2="410" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="180" y="166" text-anchor="middle" font-size="11" fill="#555">broadcast</text>
+  <text x="585" y="166" text-anchor="middle" font-size="11" fill="#555">broadcast</text>
+
+  <!-- streaming node -->
+  <rect x="80" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="195" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="195" y="242" text-anchor="middle" font-size="11" fill="#555">searches growing segments</text>
+  <text x="195" y="258" text-anchor="middle" font-size="11" fill="#555">(freshly written data)</text>
+
+  <!-- query node -->
+  <rect x="450" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="565" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Query Node</text>
+  <text x="565" y="242" text-anchor="middle" font-size="11" fill="#555">searches sealed segments</text>
+  <text x="565" y="258" text-anchor="middle" font-size="11" fill="#555">(persisted historical data)</text>
+
+  <!-- delegation between streaming and query node -->
+  <line x1="310" y1="236" x2="446" y2="236" stroke="#7f8c8d" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow3)"/>
+  <text x="378" y="226" text-anchor="middle" font-size="10" fill="#777">delegates historical part</text>
+
+  <!-- object storage -->
+  <rect x="450" y="324" width="230" height="60" rx="6" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="565" y="348" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage</text>
+  <text x="565" y="368" text-anchor="middle" font-size="11" fill="#555">sealed segments and indexes</text>
+  <line x1="565" y1="320" x2="565" y2="278" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <text x="655" y="302" text-anchor="middle" font-size="11" fill="#555">loaded in advance</text>
+
+  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">The proxy merges results from fresh and</text>
+  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">historical data and returns them to the client</text>
+</svg>

--- a/content/blog/052-milvus-architecture/img-052-003-en.svg
+++ b/content/blog/052-milvus-architecture/img-052-003-en.svg
@@ -22,13 +22,12 @@
   <text x="380" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
   <text x="380" y="132" text-anchor="middle" font-size="11" fill="#555">fan-out to shards, merge results</text>
 
-  <!-- branches -->
-  <line x1="320" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
-  <line x1="225" y1="194" x2="350" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
-  <line x1="440" y1="148" x2="575" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
-  <line x1="535" y1="194" x2="410" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
-  <text x="180" y="166" text-anchor="middle" font-size="11" fill="#555">broadcast</text>
-  <text x="585" y="166" text-anchor="middle" font-size="11" fill="#555">broadcast</text>
+  <!-- proxy to streaming node only -->
+  <line x1="330" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="225" y1="194" x2="360" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="190" y="162" text-anchor="middle" font-size="11" fill="#555">broadcast to all</text>
+  <text x="190" y="177" text-anchor="middle" font-size="11" fill="#555">Streaming Nodes</text>
+  <text x="330" y="184" text-anchor="middle" font-size="11" fill="#27ae60">shard results</text>
 
   <!-- streaming node -->
   <rect x="80" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
@@ -42,9 +41,11 @@
   <text x="565" y="242" text-anchor="middle" font-size="11" fill="#555">searches sealed segments</text>
   <text x="565" y="258" text-anchor="middle" font-size="11" fill="#555">(persisted historical data)</text>
 
-  <!-- delegation between streaming and query node -->
-  <line x1="310" y1="236" x2="446" y2="236" stroke="#7f8c8d" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow3)"/>
-  <text x="378" y="226" text-anchor="middle" font-size="10" fill="#777">delegates historical part</text>
+  <!-- delegation: streaming node -> query node, results back -->
+  <line x1="310" y1="226" x2="446" y2="226" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <text x="378" y="216" text-anchor="middle" font-size="10" fill="#777">delegates historical search</text>
+  <line x1="450" y1="254" x2="314" y2="254" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="378" y="246" text-anchor="middle" font-size="10" fill="#27ae60">results</text>
 
   <!-- object storage -->
   <rect x="450" y="324" width="230" height="60" rx="6" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
@@ -53,6 +54,6 @@
   <line x1="565" y1="320" x2="565" y2="278" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
   <text x="655" y="302" text-anchor="middle" font-size="11" fill="#555">loaded in advance</text>
 
-  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">The proxy merges results from fresh and</text>
-  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">historical data and returns them to the client</text>
+  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">The Streaming Node combines fresh + historical results,</text>
+  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">then the proxy merges all shard results for the client</text>
 </svg>

--- a/content/blog/052-milvus-architecture/img-052-003.svg
+++ b/content/blog/052-milvus-architecture/img-052-003.svg
@@ -22,13 +22,12 @@
   <text x="380" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
   <text x="380" y="132" text-anchor="middle" font-size="11" fill="#555">全シャードに配信・結果をマージ</text>
 
-  <!-- branches -->
-  <line x1="320" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
-  <line x1="225" y1="194" x2="350" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
-  <line x1="440" y1="148" x2="575" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
-  <line x1="535" y1="194" x2="410" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
-  <text x="180" y="166" text-anchor="middle" font-size="11" fill="#555">ブロードキャスト</text>
-  <text x="585" y="166" text-anchor="middle" font-size="11" fill="#555">ブロードキャスト</text>
+  <!-- proxy to streaming node only -->
+  <line x1="330" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="225" y1="194" x2="360" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="195" y="162" text-anchor="middle" font-size="11" fill="#555">全Streaming Nodeに</text>
+  <text x="195" y="177" text-anchor="middle" font-size="11" fill="#555">ブロードキャスト</text>
+  <text x="330" y="184" text-anchor="middle" font-size="11" fill="#27ae60">シャードの結果</text>
 
   <!-- streaming node -->
   <rect x="80" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
@@ -42,9 +41,11 @@
   <text x="565" y="242" text-anchor="middle" font-size="11" fill="#555">Sealed Segment を検索</text>
   <text x="565" y="258" text-anchor="middle" font-size="11" fill="#555">（永続化済みの履歴データ）</text>
 
-  <!-- delegation between streaming and query node -->
-  <line x1="310" y1="236" x2="446" y2="236" stroke="#7f8c8d" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow3)"/>
-  <text x="378" y="226" text-anchor="middle" font-size="10" fill="#777">履歴分を委譲</text>
+  <!-- delegation: streaming node -> query node, results back -->
+  <line x1="310" y1="226" x2="446" y2="226" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <text x="378" y="216" text-anchor="middle" font-size="10" fill="#777">履歴分の検索を委譲</text>
+  <line x1="450" y1="254" x2="314" y2="254" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="378" y="246" text-anchor="middle" font-size="10" fill="#27ae60">検索結果</text>
 
   <!-- object storage -->
   <rect x="450" y="324" width="230" height="60" rx="6" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
@@ -53,6 +54,6 @@
   <line x1="565" y1="320" x2="565" y2="278" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
   <text x="660" y="302" text-anchor="middle" font-size="11" fill="#555">事前にロード</text>
 
-  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">最新データと履歴データの結果を</text>
-  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">Proxyがマージしてクライアントに返す</text>
+  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">Streaming Nodeが最新＋履歴の結果をまとめ、</text>
+  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">Proxyが全シャードの結果をマージして返す</text>
 </svg>

--- a/content/blog/052-milvus-architecture/img-052-003.svg
+++ b/content/blog/052-milvus-architecture/img-052-003.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 410" font-family="sans-serif">
+  <rect width="760" height="410" fill="#ffffff"/>
+  <defs>
+    <marker id="arrow3" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7f8c8d"/>
+    </marker>
+    <marker id="arrow3r" markerWidth="10" markerHeight="10" refX="8" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#27ae60"/>
+    </marker>
+  </defs>
+
+  <!-- client -->
+  <rect x="320" y="14" width="120" height="40" rx="6" fill="#2c3e50"/>
+  <text x="380" y="39" text-anchor="middle" font-size="13" fill="#ffffff">クライアント</text>
+  <line x1="360" y1="54" x2="360" y2="88" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="400" y1="88" x2="400" y2="54" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="290" y="76" text-anchor="middle" font-size="11" fill="#555">検索リクエスト</text>
+  <text x="460" y="76" text-anchor="middle" font-size="11" fill="#27ae60">最終結果</text>
+
+  <!-- proxy -->
+  <rect x="290" y="92" width="180" height="56" rx="6" fill="#ffffff" stroke="#4a7ebb" stroke-width="1.5"/>
+  <text x="380" y="114" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Proxy</text>
+  <text x="380" y="132" text-anchor="middle" font-size="11" fill="#555">全シャードに配信・結果をマージ</text>
+
+  <!-- branches -->
+  <line x1="320" y1="148" x2="185" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="225" y1="194" x2="350" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <line x1="440" y1="148" x2="575" y2="194" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <line x1="535" y1="194" x2="410" y2="152" stroke="#27ae60" stroke-width="1.5" marker-end="url(#arrow3r)"/>
+  <text x="180" y="166" text-anchor="middle" font-size="11" fill="#555">ブロードキャスト</text>
+  <text x="585" y="166" text-anchor="middle" font-size="11" fill="#555">ブロードキャスト</text>
+
+  <!-- streaming node -->
+  <rect x="80" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="195" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Streaming Node</text>
+  <text x="195" y="242" text-anchor="middle" font-size="11" fill="#555">Growing Segment を検索</text>
+  <text x="195" y="258" text-anchor="middle" font-size="11" fill="#555">（書き込まれた直後の最新データ）</text>
+
+  <!-- query node -->
+  <rect x="450" y="198" width="230" height="76" rx="6" fill="#ffffff" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="565" y="222" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Query Node</text>
+  <text x="565" y="242" text-anchor="middle" font-size="11" fill="#555">Sealed Segment を検索</text>
+  <text x="565" y="258" text-anchor="middle" font-size="11" fill="#555">（永続化済みの履歴データ）</text>
+
+  <!-- delegation between streaming and query node -->
+  <line x1="310" y1="236" x2="446" y2="236" stroke="#7f8c8d" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow3)"/>
+  <text x="378" y="226" text-anchor="middle" font-size="10" fill="#777">履歴分を委譲</text>
+
+  <!-- object storage -->
+  <rect x="450" y="324" width="230" height="60" rx="6" fill="#f4eefb" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="565" y="348" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e50">Object Storage</text>
+  <text x="565" y="368" text-anchor="middle" font-size="11" fill="#555">Sealed Segment・インデックス</text>
+  <line x1="565" y1="320" x2="565" y2="278" stroke="#7f8c8d" stroke-width="1.5" marker-end="url(#arrow3)"/>
+  <text x="660" y="302" text-anchor="middle" font-size="11" fill="#555">事前にロード</text>
+
+  <text x="230" y="330" text-anchor="middle" font-size="12" fill="#555">最新データと履歴データの結果を</text>
+  <text x="230" y="350" text-anchor="middle" font-size="12" fill="#555">Proxyがマージしてクライアントに返す</text>
+</svg>

--- a/content/blog/052-milvus-architecture/index.en.md
+++ b/content/blog/052-milvus-architecture/index.en.md
@@ -1,6 +1,6 @@
 +++
 title = 'Milvus Architecture Explained: Understanding the Four-Layer Design and Data Flows with Diagrams'
-description = 'A clear, diagram-based walkthrough of the Milvus vector database architecture: the four layers (Proxy, Coordinator, worker nodes, storage), write and search data flows, growing/sealed segments, and the Woodpecker WAL — all based on the official documentation.'
+description = 'A clear, diagram-based guide to the Milvus vector database architecture: its four layers, write and search data flows, segments, and the Woodpecker WAL.'
 date = 2026-06-11T00:00:00+09:00
 draft = false
 categories = ["Engineering"]
@@ -11,7 +11,7 @@ tags = ["Milvus", "Vector Search", "Database", "AI"]
 
 With the rise of RAG (Retrieval-Augmented Generation) and recommendation systems, more and more teams are adopting **Milvus**, one of the most popular vector databases. Getting started with Milvus through its SDK is easy, but once you reach production operations and tuning, understanding how data actually flows inside the system makes a huge difference.
 
-In this article, I explain the Milvus architecture based on the official documentation, with diagrams to make it easy to follow. You can also read it as a follow-up to my previous article, "[Introduction to Approximate Nearest Neighbor Search (ANN)](/en/blog/051-ann-basics/)", showing how those search algorithms operate as a distributed system.
+In this article, I explain the Milvus architecture based on the official documentation, with diagrams to make it easy to follow. You can also read it as a follow-up to my previous article, "[Introduction to Approximate Nearest Neighbor (ANN) Search](/en/blog/051-ann-basics/)", showing how those search algorithms operate as a distributed system.
 
 Note that this article is based on the official documentation for **Milvus 2.6** ([Milvus Architecture Overview](https://milvus.io/docs/architecture_overview.md)). The architecture was significantly reorganized in 2.6, so the component layout differs from earlier versions.
 
@@ -26,7 +26,7 @@ Two design principles define its architecture:
 
 ## The Four-Layer Architecture at a Glance
 
-A Milvus cluster consists of four layers (source: [Milvus Architecture Overview](https://milvus.io/docs/four_layers.md)).
+A Milvus cluster consists of four layers (source: [Storage/Computing Disaggregation](https://milvus.io/docs/four_layers.md)).
 
 ![The four-layer Milvus architecture: access layer (Proxy), control plane (Coordinator), worker nodes (Streaming/Query/Data Node), and storage layer (WAL/Object/Meta Storage)](img-052-001-en.svg)
 
@@ -50,7 +50,7 @@ The Coordinator is described in the official documentation as "**the brain of Mi
 - Managing Query Node topology and load balancing
 - Distributing offline tasks such as compaction and index building
 
-Exactly one Coordinator is active in the cluster, with master-slave options available for high availability.
+Exactly one Coordinator is active in the cluster, and a master-slave mode can be enabled for high availability (source: [Milvus Main Components](https://milvus.io/docs/main_components.md)).
 
 ### Worker Nodes (Execution Layer)
 
@@ -86,7 +86,7 @@ Let's look at how an insert request is processed (source: [Data Processing in Mi
 2. **The Streaming Node assigns a TSO**: the Streaming Node responsible for each vchannel assigns a timestamp (TSO) to guarantee operation ordering and validates consistency
 3. **Write to the WAL**: data is appended to WAL storage, and **the write is considered successful once it is durable there**. After a crash, the Streaming Node can replay the WAL to fully recover all pending operations
 4. **Applied to a growing segment**: the Streaming Node asynchronously converts WAL entries into segments. Freshly written data becomes an in-memory **growing segment** and is already searchable at this point
-5. **Flush turns it into a sealed segment**: when a flush is triggered, the growing segment becomes a **sealed segment** — immutable and persisted — in object storage
+5. **Flush turns it into a sealed segment**: when a flush is triggered — for example, once the segment reaches its capacity threshold — the growing segment becomes a **sealed segment** — immutable and persisted — in object storage
 6. **The Data Node builds indexes**: the Data Node builds an index for each sealed segment independently and stores the result back in object storage
 
 Because vector index building is computationally demanding, it relies on **SIMD acceleration** with instruction sets such as SSE, AVX2, and AVX512. Scalar fields use structures like Bloom filters and inverted indexes.
@@ -95,7 +95,7 @@ Because vector index building is computationally demanding, it relies on **SIMD 
 
 A search request flows in the opposite direction: it gathers data that is spread across the cluster.
 
-![The Milvus search path: the proxy broadcasts to all shards, Streaming Nodes search growing segments while Query Nodes search sealed segments, and the proxy merges the results](img-052-003-en.svg)
+![The Milvus search path: the proxy broadcasts to the Streaming Nodes of all shards, each Streaming Node searches growing segments and delegates sealed-segment search to Query Nodes, and the proxy merges the per-shard results](img-052-003-en.svg)
 
 1. **The proxy broadcasts to all shards**: the search request is sent concurrently to every Streaming Node responsible for the related shards
 2. **Streaming Nodes search the freshest data**: each Streaming Node generates a query plan and searches its local growing segments (data written moments ago)

--- a/content/blog/052-milvus-architecture/index.en.md
+++ b/content/blog/052-milvus-architecture/index.en.md
@@ -1,0 +1,144 @@
++++
+title = 'Milvus Architecture Explained: Understanding the Four-Layer Design and Data Flows with Diagrams'
+description = 'A clear, diagram-based walkthrough of the Milvus vector database architecture: the four layers (Proxy, Coordinator, worker nodes, storage), write and search data flows, growing/sealed segments, and the Woodpecker WAL — all based on the official documentation.'
+date = 2026-06-11T00:00:00+09:00
+draft = false
+categories = ["Engineering"]
+tags = ["Milvus", "Vector Search", "Database", "AI"]
++++
+
+## Overview
+
+With the rise of RAG (Retrieval-Augmented Generation) and recommendation systems, more and more teams are adopting **Milvus**, one of the most popular vector databases. Getting started with Milvus through its SDK is easy, but once you reach production operations and tuning, understanding how data actually flows inside the system makes a huge difference.
+
+In this article, I explain the Milvus architecture based on the official documentation, with diagrams to make it easy to follow. You can also read it as a follow-up to my previous article, "[Introduction to Approximate Nearest Neighbor Search (ANN)](/en/blog/051-ann-basics/)", showing how those search algorithms operate as a distributed system.
+
+Note that this article is based on the official documentation for **Milvus 2.6** ([Milvus Architecture Overview](https://milvus.io/docs/architecture_overview.md)). The architecture was significantly reorganized in 2.6, so the component layout differs from earlier versions.
+
+## What Is Milvus?
+
+Milvus is an **open-source, cloud-native vector database** designed for high-performance similarity search. Internally it leverages vector search libraries such as Faiss, HNSW, DiskANN, and SCANN, and it is widely used as a search backbone for AI applications and unstructured data (source: [Milvus Architecture Overview](https://milvus.io/docs/architecture_overview.md)).
+
+Two design principles define its architecture:
+
+- **Disaggregation of storage and computing**: all components are stateless, and the actual data lives in external storage
+- **Separation of the data plane and control plane**: the components that process data and the components that manage the cluster are independent, so each can scale horizontally
+
+## The Four-Layer Architecture at a Glance
+
+A Milvus cluster consists of four layers (source: [Milvus Architecture Overview](https://milvus.io/docs/four_layers.md)).
+
+![The four-layer Milvus architecture: access layer (Proxy), control plane (Coordinator), worker nodes (Streaming/Query/Data Node), and storage layer (WAL/Object/Meta Storage)](img-052-001-en.svg)
+
+### Access Layer
+
+The access layer is a set of **stateless proxies** that receive client requests first. Their responsibilities are:
+
+- Validating requests
+- Providing a unified service endpoint together with load balancers such as Nginx or Kubernetes Ingress
+- Aggregating intermediate results from worker nodes and returning the final result to the client
+
+Because Milvus follows a massively parallel processing (MPP) design, it is the proxy that consolidates partial results into the final answer.
+
+### Control Plane (Coordinator)
+
+The Coordinator is described in the official documentation as "**the brain of Milvus**". It maintains cluster topology, schedules work, and ensures consistency. Its concrete responsibilities include:
+
+- Handling DDL/DCL operations (creating collections, managing permissions, and so on)
+- Timestamp management via the **TSO (Timestamp Oracle)**
+- Managing WAL bindings with Streaming Nodes
+- Managing Query Node topology and load balancing
+- Distributing offline tasks such as compaction and index building
+
+Exactly one Coordinator is active in the cluster, with master-slave options available for high availability.
+
+### Worker Nodes (Execution Layer)
+
+Three types of stateless nodes execute the Coordinator's instructions. The table below summarizes their roles.
+
+| Node | Main role | Data handled |
+| --- | --- | --- |
+| Streaming Node | Real-time writes, shard-level consistency and recovery via the WAL, search on incremental data, converting growing data into sealed segments | Growing segments (freshly written data) |
+| Query Node | Loading historical data from object storage and searching it | Sealed segments (persisted data) |
+| Data Node | Offline processing such as compaction and index building | Sealed segments |
+
+In Milvus 2.6, the roles were cleanly split — stream processing goes to the Streaming Node, batch processing goes to the Query Node and Data Node — achieving both real-time performance and high throughput (source: [Introducing Milvus 2.6](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)).
+
+### Storage Layer
+
+The storage layer holds the actual data and consists of three kinds of storage.
+
+| Storage | Role | Implementations |
+| --- | --- | --- |
+| Meta Storage | Metadata snapshots, service registration | etcd |
+| WAL Storage | Durability of writes (write-ahead logging) | Woodpecker, Kafka, Pulsar |
+| Object Storage | Segments (log snapshots) and index files | MinIO, AWS S3, Azure Blob |
+
+The reason every worker node can stay stateless is that all state is pushed down into this layer. Even if a node crashes, data can be recovered from the WAL and object storage.
+
+## The Write Path
+
+Let's look at how an insert request is processed (source: [Data Processing in Milvus](https://milvus.io/docs/data_processing.md)).
+
+![The Milvus write path: the proxy splits data by shard, the Streaming Node assigns a TSO and persists the data to the WAL, and data moves from growing segments to sealed segments in object storage](img-052-002-en.svg)
+
+1. **The proxy routes data to shards**: a collection is divided into multiple **shards**, and each shard maps to a **vchannel (virtual channel)**. The proxy splits incoming data into per-shard packages according to the shard routing rules
+2. **The Streaming Node assigns a TSO**: the Streaming Node responsible for each vchannel assigns a timestamp (TSO) to guarantee operation ordering and validates consistency
+3. **Write to the WAL**: data is appended to WAL storage, and **the write is considered successful once it is durable there**. After a crash, the Streaming Node can replay the WAL to fully recover all pending operations
+4. **Applied to a growing segment**: the Streaming Node asynchronously converts WAL entries into segments. Freshly written data becomes an in-memory **growing segment** and is already searchable at this point
+5. **Flush turns it into a sealed segment**: when a flush is triggered, the growing segment becomes a **sealed segment** — immutable and persisted — in object storage
+6. **The Data Node builds indexes**: the Data Node builds an index for each sealed segment independently and stores the result back in object storage
+
+Because vector index building is computationally demanding, it relies on **SIMD acceleration** with instruction sets such as SSE, AVX2, and AVX512. Scalar fields use structures like Bloom filters and inverted indexes.
+
+## The Search Path
+
+A search request flows in the opposite direction: it gathers data that is spread across the cluster.
+
+![The Milvus search path: the proxy broadcasts to all shards, Streaming Nodes search growing segments while Query Nodes search sealed segments, and the proxy merges the results](img-052-003-en.svg)
+
+1. **The proxy broadcasts to all shards**: the search request is sent concurrently to every Streaming Node responsible for the related shards
+2. **Streaming Nodes search the freshest data**: each Streaming Node generates a query plan and searches its local growing segments (data written moments ago)
+3. **Query Nodes search historical data**: each Streaming Node also delegates the search over sealed segments (historical data) to remote Query Nodes, which search using segments and indexes loaded in advance from object storage
+4. **The proxy merges the results**: the proxy collects the results from all shards, merges them, and returns the final outcome to the client
+
+This design lets Milvus **return just-written data in search results while still searching massive historical data quickly through indexes**. When growing segments are flushed into sealed segments, the Coordinator performs a **handoff**, distributing the sealed segments evenly across the Query Nodes.
+
+## Deployment Modes: Standalone vs. Cluster
+
+Milvus offers two main deployment modes (source: [Milvus Main Components](https://milvus.io/docs/main_components.md)).
+
+- **Standalone mode**: all components run in a single process. It suits small datasets and low workloads, and it can use embedded WAL implementations such as Woodpecker or rocksmq, eliminating third-party middleware dependencies. Note that **you cannot perform an online upgrade from a standalone instance to a cluster**
+- **Cluster mode**: each component runs as an independent process and can be scaled out individually on Kubernetes. This mode is for large datasets and high-load production environments
+
+A typical setup is standalone for development and testing, and cluster mode for production.
+
+## How the Architecture Evolved in Milvus 2.6
+
+Finally, here are the major architectural changes introduced in Milvus 2.6 (source: [Introducing Milvus 2.6](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)).
+
+- **Introduction of the Streaming Node**: real-time responsibilities that were scattered across multiple components in 2.5 — consuming the message queue, writing incremental segments, serving incremental queries, and WAL-based recovery — are now consolidated into a dedicated Streaming Node
+- **Woodpecker (zero-disk WAL)**: a cloud-native WAL system built to remove the dependency on external message queues like Kafka and Pulsar. With its "zero-disk" design, all log data is persisted directly in object storage, with no reliance on local disks (source: [Woodpecker Architecture](https://milvus.io/docs/woodpecker_architecture.md))
+- **Coordinator merge**: the previously separate coordinators (RootCoord, QueryCoord, DataCoord, and so on) were merged into a single Coordinator, simplifying operations
+
+All of these changes move in the same direction: fewer external dependencies and a simpler, cloud-native architecture that reduces cost and operational burden.
+
+## Summary
+
+In this article, I walked through the Milvus architecture based on the official documentation.
+
+- Milvus is a cloud-native design built on **storage/computing disaggregation**, consisting of four layers: the access layer (Proxy), the control plane (Coordinator), worker nodes, and the storage layer
+- The worker nodes have clearly separated roles: **the Streaming Node handles real-time processing, the Query Node searches historical data, and the Data Node handles offline processing**
+- Writes are processed in stages — committed once durable in the WAL, then growing segment, then sealed segment via flush — while searches merge results from fresh and historical data at the proxy
+- Milvus 2.6 introduced the Streaming Node and Woodpecker (zero-disk WAL) and merged the coordinators, evolving toward a simpler architecture with fewer external dependencies
+
+Understanding these internal data flows makes it clear why just-written data shows up in search results and why data survives node failures — knowledge that pays off in capacity planning and troubleshooting in production.
+
+## References
+
+- [Milvus Architecture Overview | Milvus Documentation](https://milvus.io/docs/architecture_overview.md)
+- [Storage/Computing Disaggregation | Milvus Documentation](https://milvus.io/docs/four_layers.md)
+- [Main Components | Milvus Documentation](https://milvus.io/docs/main_components.md)
+- [Data Processing | Milvus Documentation](https://milvus.io/docs/data_processing.md)
+- [Introducing Milvus 2.6: Affordable Vector Search at Billion Scale | Milvus Blog](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)
+- [Woodpecker Architecture | Milvus Documentation](https://milvus.io/docs/woodpecker_architecture.md)

--- a/content/blog/052-milvus-architecture/index.md
+++ b/content/blog/052-milvus-architecture/index.md
@@ -26,7 +26,7 @@ Milvusは、高性能な類似検索のために設計された **オープン�
 
 ## 4層アーキテクチャの全体像
 
-Milvusのクラスタは、大きく4つの層で構成されます（出典: [Milvus Architecture Overview](https://milvus.io/docs/four_layers.md)）。
+Milvusのクラスタは、大きく4つの層で構成されます（出典: [Storage/Computing Disaggregation](https://milvus.io/docs/four_layers.md)）。
 
 ![Milvusの4層アーキテクチャ：アクセス層（Proxy）、制御プレーン（Coordinator）、ワーカーノード（Streaming/Query/Data Node）、ストレージ層（WAL/Object/Meta Storage）](img-052-001.svg)
 
@@ -50,7 +50,7 @@ Coordinatorは公式ドキュメントで「**Milvusの頭脳（the brain of Mil
 - Query Nodeのトポロジ管理と負荷分散
 - コンパクションやインデックス構築といったオフラインタスクの分配
 
-アクティブなCoordinatorはクラスタに1つで、高可用性のためのマスター・スレーブ構成にも対応しています。
+アクティブなCoordinatorはクラスタに1つで、高可用性のためにマスター・スレーブ構成を有効化することもできます（出典: [Milvusの主要コンポーネント](https://milvus.io/docs/main_components.md)）。
 
 ### ワーカーノード（実行層）
 
@@ -86,7 +86,7 @@ Milvus 2.6では「ストリーム処理はStreaming Node、バッチ処理はQu
 2. **Streaming NodeがTSOを付与**: 各vchannelを担当するStreaming Nodeが、操作の順序を保証するためのタイムスタンプ（TSO）を割り当て、整合性を検証します
 3. **WALへ書き込み**: データはまずWAL Storageに追記され、**永続化が完了した時点で書き込み成功** となります。クラッシュしてもWALをリプレイすれば未反映の操作を完全に復元できます
 4. **Growing Segmentに反映**: Streaming NodeはWALのエントリを非同期にセグメントへ変換します。書き込み直後のデータは **Growing Segment** と呼ばれるメモリ上の増分データとなり、この時点ですでに検索対象になります
-5. **FlushでSealed Segmentへ**: 一定の条件でFlushが実行されると、Growing Segmentは **Sealed Segment**（不変・永続化済み）としてオブジェクトストレージに書き出されます
+5. **FlushでSealed Segmentへ**: セグメントが容量のしきい値に達するなどの条件でFlushが実行されると、Growing Segmentは **Sealed Segment**（不変・永続化済み）としてオブジェクトストレージに書き出されます
 6. **Data Nodeがインデックスを構築**: Sealed Segmentに対して、Data Nodeがセグメント単位でインデックスを構築し、結果をオブジェクトストレージに保存します
 
 ベクトルインデックスの構築は計算負荷が高いため、SSE・AVX2・AVX512といった **SIMD命令によるアクセラレーション** が活用されます。スカラーフィールドにはBloomフィルタや転置インデックスなどが使われます。
@@ -95,7 +95,7 @@ Milvus 2.6では「ストリーム処理はStreaming Node、バッチ処理はQu
 
 検索リクエストは、書き込みとは逆に「散らばったデータをかき集める」流れになります。
 
-![Milvusの検索フロー：Proxyが全シャードにブロードキャストし、Streaming NodeがGrowing Segmentを、Query NodeがSealed Segmentを検索、Proxyが結果をマージして返す](img-052-003.svg)
+![Milvusの検索フロー：Proxyが全シャードのStreaming Nodeにブロードキャストし、Streaming NodeがGrowing Segmentを検索しつつSealed Segmentの検索をQuery Nodeに委譲、Proxyがシャードごとの結果をマージして返す](img-052-003.svg)
 
 1. **Proxyが全シャードにブロードキャスト**: 検索リクエストは、関係するシャードを担当するすべてのStreaming Nodeに並行して配信されます
 2. **Streaming Nodeが最新データを検索**: 各Streaming Nodeはクエリプランを生成し、ローカルのGrowing Segment（書き込まれた直後のデータ）を検索します

--- a/content/blog/052-milvus-architecture/index.md
+++ b/content/blog/052-milvus-architecture/index.md
@@ -1,0 +1,144 @@
++++
+title = 'Milvusのアーキテクチャをわかりやすく解説：4層構成とデータの流れを図解で理解する'
+description = 'オープンソースのベクトルデータベースMilvusのアーキテクチャを図解でわかりやすく解説。Proxy・Coordinator・ワーカーノード・ストレージの4層構成、書き込みと検索のデータフロー、Growing/Sealed Segment、Woodpecker WALまで公式ドキュメントに基づき紹介します。'
+date = 2026-06-11T00:00:00+09:00
+draft = false
+categories = ["Engineering"]
+tags = ["Milvus", "Vector Search", "Database", "AI"]
++++
+
+## 概要
+
+RAG（検索拡張生成）やレコメンドの普及にともない、ベクトルデータベースの代表格である **Milvus** を採用する機会が増えています。Milvusは「とりあえず使う」だけならSDK経由で簡単に触れますが、本番運用やチューニングの段階になると、内部でデータがどう流れているかを理解しているかどうかで対応力が大きく変わります。
+
+本記事では、Milvusのアーキテクチャを公式ドキュメントに基づいて、図解を交えながらわかりやすく解説します。前回の記事「[近似最近傍探索（ANN）入門](/blog/051-ann-basics/)」で扱った検索アルゴリズムが、システムとしてどう動くのかという視点でも読めるはずです。
+
+なお、本記事は **Milvus 2.6系** の公式ドキュメント（[Milvus Architecture Overview](https://milvus.io/docs/architecture_overview.md)）に基づいています。2.6でアーキテクチャが大きく整理されたため、それ以前のバージョンとはコンポーネント構成が異なる点にご注意ください。
+
+## Milvusとは
+
+Milvusは、高性能な類似検索のために設計された **オープンソースのクラウドネイティブなベクトルデータベース** です。内部ではFaiss、HNSW、DiskANN、SCANNといったベクトル検索ライブラリを活用しており、AIアプリケーションや非構造化データの検索基盤として広く使われています（出典: [Milvus Architecture Overview](https://milvus.io/docs/architecture_overview.md)）。
+
+アーキテクチャ上の最大の特徴は、次の2つの設計原則です。
+
+- **ストレージとコンピューティングの分離**: すべてのコンポーネントはステートレスで、データの実体は外部ストレージに置かれます
+- **データプレーンと制御プレーンの分離**: 「データを処理する役割」と「クラスタを管理する役割」を独立させ、それぞれを水平スケールできるようにしています
+
+## 4層アーキテクチャの全体像
+
+Milvusのクラスタは、大きく4つの層で構成されます（出典: [Milvus Architecture Overview](https://milvus.io/docs/four_layers.md)）。
+
+![Milvusの4層アーキテクチャ：アクセス層（Proxy）、制御プレーン（Coordinator）、ワーカーノード（Streaming/Query/Data Node）、ストレージ層（WAL/Object/Meta Storage）](img-052-001.svg)
+
+### アクセス層（Access Layer）
+
+クライアントからのリクエストを最初に受け付ける、**ステートレスなProxy** の集まりです。役割は次の通りです。
+
+- リクエストの検証（バリデーション）
+- NginxやKubernetes Ingressなどのロードバランサーと組み合わせた、統一エンドポイントの提供
+- 各ノードから返ってくる中間結果を集約し、最終結果としてクライアントに返却
+
+Milvusは大規模並列処理（MPP）型の設計のため、「結果をまとめ上げる」役割をProxyが担っている点がポイントです。
+
+### 制御プレーン（Coordinator）
+
+Coordinatorは公式ドキュメントで「**Milvusの頭脳（the brain of Milvus）**」と表現されるコンポーネントで、クラスタ全体のトポロジ管理・スケジューリング・一貫性の維持を担います。具体的な責務は以下の通りです。
+
+- DDL/DCL（コレクション作成や権限管理など）の処理
+- **TSO（Timestamp Oracle）** によるタイムスタンプ管理
+- WALとStreaming Nodeの割り当て管理
+- Query Nodeのトポロジ管理と負荷分散
+- コンパクションやインデックス構築といったオフラインタスクの分配
+
+アクティブなCoordinatorはクラスタに1つで、高可用性のためのマスター・スレーブ構成にも対応しています。
+
+### ワーカーノード（実行層）
+
+Coordinatorの指示を実行する、ステートレスな3種類のノードです。役割の違いを表にまとめます。
+
+| ノード | 主な役割 | 扱うデータ |
+| --- | --- | --- |
+| Streaming Node | リアルタイム書き込み、WALによるシャード単位の一貫性・リカバリ、増分データの検索、Growing→Sealedへの変換 | Growing Segment（書き込み直後のデータ） |
+| Query Node | オブジェクトストレージから履歴データをロードして検索 | Sealed Segment（永続化済みデータ） |
+| Data Node | コンパクションやインデックス構築などのオフライン処理 | Sealed Segment |
+
+Milvus 2.6では「ストリーム処理はStreaming Node、バッチ処理はQuery NodeとData Node」と役割が明確に分離され、リアルタイム性とスループットを両立する構成になりました（出典: [Introducing Milvus 2.6](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)）。
+
+### ストレージ層
+
+データの実体を保持する層で、3種類のストレージから構成されます。
+
+| ストレージ | 役割 | 実装例 |
+| --- | --- | --- |
+| Meta Storage | メタデータのスナップショット、サービス登録 | etcd |
+| WAL Storage | 書き込みの永続性保証（先行書き込みログ） | Woodpecker、Kafka、Pulsar |
+| Object Storage | セグメント（ログスナップショット）、インデックスファイルの保存 | MinIO、AWS S3、Azure Blob |
+
+ワーカーノードがすべてステートレスでいられるのは、状態をこの層に追い出しているためです。ノードが落ちても、WALとオブジェクトストレージからデータを復元できます。
+
+## データの書き込みフロー
+
+次に、Insertリクエストがどう処理されるかを見てみましょう（出典: [Milvusのデータ処理](https://milvus.io/docs/data_processing.md)）。
+
+![Milvusの書き込みフロー：Proxyがシャードに分割し、Streaming NodeがTSOを付与してWALに永続化、Growing Segmentを経てSealed SegmentとしてObject Storageに保存される](img-052-002.svg)
+
+1. **Proxyがシャードに振り分ける**: コレクションは複数の **シャード** に分割されており、各シャードは **vchannel（仮想チャネル）** に対応します。Proxyはルーティングルールに従って書き込みデータをシャード単位に分割します
+2. **Streaming NodeがTSOを付与**: 各vchannelを担当するStreaming Nodeが、操作の順序を保証するためのタイムスタンプ（TSO）を割り当て、整合性を検証します
+3. **WALへ書き込み**: データはまずWAL Storageに追記され、**永続化が完了した時点で書き込み成功** となります。クラッシュしてもWALをリプレイすれば未反映の操作を完全に復元できます
+4. **Growing Segmentに反映**: Streaming NodeはWALのエントリを非同期にセグメントへ変換します。書き込み直後のデータは **Growing Segment** と呼ばれるメモリ上の増分データとなり、この時点ですでに検索対象になります
+5. **FlushでSealed Segmentへ**: 一定の条件でFlushが実行されると、Growing Segmentは **Sealed Segment**（不変・永続化済み）としてオブジェクトストレージに書き出されます
+6. **Data Nodeがインデックスを構築**: Sealed Segmentに対して、Data Nodeがセグメント単位でインデックスを構築し、結果をオブジェクトストレージに保存します
+
+ベクトルインデックスの構築は計算負荷が高いため、SSE・AVX2・AVX512といった **SIMD命令によるアクセラレーション** が活用されます。スカラーフィールドにはBloomフィルタや転置インデックスなどが使われます。
+
+## 検索（クエリ）フロー
+
+検索リクエストは、書き込みとは逆に「散らばったデータをかき集める」流れになります。
+
+![Milvusの検索フロー：Proxyが全シャードにブロードキャストし、Streaming NodeがGrowing Segmentを、Query NodeがSealed Segmentを検索、Proxyが結果をマージして返す](img-052-003.svg)
+
+1. **Proxyが全シャードにブロードキャスト**: 検索リクエストは、関係するシャードを担当するすべてのStreaming Nodeに並行して配信されます
+2. **Streaming Nodeが最新データを検索**: 各Streaming Nodeはクエリプランを生成し、ローカルのGrowing Segment（書き込まれた直後のデータ）を検索します
+3. **Query Nodeが履歴データを検索**: あわせてStreaming Nodeは、Sealed Segment（履歴データ）の検索をリモートのQuery Nodeに委譲します。Query Nodeはオブジェクトストレージから事前にロードしたセグメントとインデックスを使って検索します
+4. **Proxyが結果をマージ**: 各シャードの結果をProxyが集約・マージし、最終結果としてクライアントに返します
+
+この仕組みにより、**書き込んだ直後のデータも検索にヒットしつつ、大量の履歴データはインデックスで高速に検索する** という両立が実現されています。なお、Growing SegmentがFlushされてSealed Segmentになると、Coordinatorが **ハンドオフ** を行い、Sealed SegmentをQuery Node群に均等に分配します。
+
+## デプロイモード：スタンドアロンとクラスタ
+
+Milvusには大きく2つのデプロイモードがあります（出典: [Milvusの主要コンポーネント](https://milvus.io/docs/main_components.md)）。
+
+- **スタンドアロンモード**: 全コンポーネントを1プロセスで動かす構成です。小規模データ・低負荷向けで、WALにはWoodpeckerやrocksmqなどの組み込み実装を使えるため、外部ミドルウェアへの依存をなくせます。ただし、スタンドアロンからクラスタへの **オンラインアップグレードはできない** 点に注意が必要です
+- **クラスタモード**: 各コンポーネントを独立したプロセスとして動かし、Kubernetes上でそれぞれを水平スケールできる構成です。大規模データ・高負荷の本番環境向けです
+
+開発・検証はスタンドアロン、本番はクラスタ、という使い分けが基本になります。
+
+## Milvus 2.6でのアーキテクチャの進化
+
+最後に、Milvus 2.6で行われた大きなアーキテクチャ変更を押さえておきます（出典: [Introducing Milvus 2.6](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)）。
+
+- **Streaming Nodeの導入**: 2.5まで複数コンポーネントにまたがっていたリアルタイム処理（メッセージ消費、増分セグメントの書き込み、増分データの検索、WALベースのリカバリ）が、専任のStreaming Nodeに集約されました
+- **Woodpecker（ゼロディスクWAL）**: KafkaやPulsarといった外部メッセージキューへの依存をなくすために開発された、クラウドネイティブなWALシステムです。ログデータをすべてオブジェクトストレージに永続化する「ゼロディスク」設計で、ローカルディスクに依存しません（出典: [Woodpecker Architecture](https://milvus.io/docs/woodpecker_architecture.md)）
+- **Coordinatorの統合**: 以前は分かれていた複数のコーディネータ（RootCoord、QueryCoord、DataCoordなど）が単一のCoordinatorに統合され、運用がシンプルになりました
+
+いずれも「外部依存を減らし、クラウドネイティブな構成でコストと運用負荷を下げる」方向の進化と言えます。
+
+## まとめ
+
+本記事では、Milvusのアーキテクチャを公式ドキュメントに基づいて解説しました。
+
+- Milvusは **ストレージとコンピューティングの分離** を徹底したクラウドネイティブ設計で、アクセス層（Proxy）・制御プレーン（Coordinator）・ワーカーノード・ストレージ層の4層で構成される
+- ワーカーノードは役割分担が明確で、**Streaming Nodeがリアルタイム処理、Query Nodeが履歴データの検索、Data Nodeがオフライン処理** を担う
+- 書き込みは「WALへの永続化で確定 → Growing Segment → FlushでSealed Segment化」と段階的に処理され、検索は最新データと履歴データの結果をProxyがマージして返す
+- Milvus 2.6ではStreaming NodeとWoodpecker（ゼロディスクWAL）の導入、Coordinatorの統合により、外部依存の少ないシンプルな構成に進化した
+
+内部のデータフローを理解しておくと、「書き込み直後のデータが検索にヒットする仕組み」や「ノード障害時にデータが失われない理由」が腹落ちし、本番運用時のキャパシティプランニングやトラブルシューティングにも役立ちます。
+
+## 参考資料
+
+- [Milvus Architecture Overview | Milvus Documentation](https://milvus.io/docs/architecture_overview.md)
+- [Storage/Computing Disaggregation | Milvus Documentation](https://milvus.io/docs/four_layers.md)
+- [Main Components | Milvus Documentation](https://milvus.io/docs/main_components.md)
+- [Data Processing | Milvus Documentation](https://milvus.io/docs/data_processing.md)
+- [Introducing Milvus 2.6: Affordable Vector Search at Billion Scale | Milvus Blog](https://milvus.io/blog/introduce-milvus-2-6-built-for-scale-designed-to-reduce-costs.md)
+- [Woodpecker Architecture | Milvus Documentation](https://milvus.io/docs/woodpecker_architecture.md)


### PR DESCRIPTION
## 概要

ベクトルデータベースMilvusのアーキテクチャを解説する新規記事 `content/blog/052-milvus-architecture/` を追加します。

## 内容

- **記事**: 日本語（`index.md`）＋英語（`index.en.md`）
- **図**: 自作SVG 6点（日英各3点）
  - 4層アーキテクチャ全体図（アクセス層・制御プレーン・ワーカーノード・ストレージ層）
  - 書き込みフロー（shard/vchannel → TSO → WAL → Growing/Sealed Segment）
  - 検索フロー（Proxyブロードキャスト → Streaming Node / Query Node → マージ）
- **出典**: Milvus 2.6系の公式ドキュメント（Architecture Overview / Four Layers / Main Components / Data Processing / Woodpecker / 2.6リリースブログ）をインライン出典＋参考資料セクションで明記

## 検証

- デプロイと同一の Hugo 0.120.3 extended で `hugo --minify` のビルド成功を確認（日英両ページ生成、図・内部リンクの埋め込みを確認済み）
- レビューAgentによる内部レビューを実施し、指摘事項（検索フロー図の矢印が公式ドキュメントと不一致、出典リンクテキストの不整合、英語descriptionの長さ等）を修正済み
- 公式ドキュメント（milvus-docs v2.6.x）と記述内容の照合済み

https://claude.ai/code/session_01W1A6VbhFaZDpDZpw48K7k3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1A6VbhFaZDpDZpw48K7k3)_